### PR TITLE
add language and country to training set generation

### DIFF
--- a/model/dataset/prompts.py
+++ b/model/dataset/prompts.py
@@ -90,7 +90,9 @@ class PromptBuilder:
 
     @staticmethod
     def build_generation_prompt(
-        labels: dict[str, str], languages: list[str], sample_index: int = 0
+        labels: dict[str, str],
+        languages_countries: list[tuple[str, str]],
+        sample_index: int = 0,
     ) -> str:
         """
         Build a prompt for generating PII samples.
@@ -108,7 +110,11 @@ class PromptBuilder:
         """
 
         # Pick one language randomly from the list
-        selected_language = random.choice(languages) if languages else "English"
+        selected_language_country = (
+            random.choice(languages_countries)
+            if languages_countries
+            else ("English", "United States")
+        )
 
         # Add variety in writing style and context
         writing_styles = [
@@ -141,13 +147,15 @@ class PromptBuilder:
         correct_firstname_only = '{"value": "Ravi", "label": "FIRSTNAME"}'
         correct_both = '{"value": "Ravi", "label": "FIRSTNAME"} {"value": "Patel", "label": "SURNAME"}'
 
+        language = selected_language_country[0]
+        country = selected_language_country[1]
         labels_list = ", ".join(labels.values())
         return f"""
         Generate one text sample in the style of a {style} that contains the following PII types:
         {labels_list}
 
         Instructions:
-            1. Generate the sample in {selected_language} language and make the text as well as the PII data as realistic to the language (e.g. use German, Swiss or Austrian addresses, phone numbers, dates, etc. for German).
+            1. Generate the sample in `{language}` and make the text as well as the PII data as realistic to the geographic area of `{country}`.
             2. Use only the PII types listed above
             3. Write in the style of a {style} - make it realistic and contextually appropriate
             4. {complexity}

--- a/model/dataset/schemas.py
+++ b/model/dataset/schemas.py
@@ -9,6 +9,14 @@ def get_pii_sample_schema() -> dict:
             "type": "object",
             "properties": {
                 "text": {"type": "string"},
+                "language": {
+                    "type": "string",
+                    "description": "Language of the text sample (e.g., 'English', 'Spanish', 'French')",
+                },
+                "country": {
+                    "type": "string",
+                    "description": "Geographic area/country for the text sample (e.g., 'United States', 'France', 'Japan')",
+                },
                 "privacy_mask": {
                     "type": "array",
                     "items": {
@@ -46,7 +54,7 @@ def get_pii_sample_schema() -> dict:
                     "description": "Coreference clusters grouping mentions that refer to the same entity",
                 },
             },
-            "required": ["text", "privacy_mask", "coreferences"],
+            "required": ["text", "privacy_mask", "coreferences", "language", "country"],
             "additionalProperties": False,
         },
     }
@@ -58,6 +66,14 @@ def get_review_sample_schema() -> dict:
         "type": "object",
         "properties": {
             "text": {"type": "string"},
+            "language": {
+                "type": "string",
+                "description": "Language of the text sample (e.g., 'English', 'Spanish', 'French')",
+            },
+            "country": {
+                "type": "string",
+                "description": "Geographic area/country for the text sample (e.g., 'United States', 'France', 'Japan')",
+            },
             "privacy_mask": {
                 "type": "array",
                 "items": {
@@ -95,6 +111,6 @@ def get_review_sample_schema() -> dict:
                 "description": "Coreference clusters grouping mentions that refer to the same entity",
             },
         },
-        "required": ["text", "privacy_mask", "coreferences"],
+        "required": ["text", "privacy_mask", "coreferences", "language", "country"],
         "additionalProperties": False,
     }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added support for language-country pair configurations to enable region-specific training and prompt generation.
  * Enhanced prompt generation with geographic context for improved localization handling.

* **Schema Updates**
  * Added required `language` and `country` fields to data sample schemas for better regional classification.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->