### PR TITLE
fixing file location instead of text

### DIFF
--- a/env.example
+++ b/env.example
@@ -4,5 +4,5 @@ OPENAI_API_KEY=sk-....
 # Transparent Proxy Configuration
 # TRANSPARENT_PROXY_ENABLED=true
 # TRANSPARENT_PROXY_PORT=:8080
-# TRANSPARENT_PROXY_CA_PATH=~/.yaak-proxy/ca-cert.pem
-# TRANSPARENT_PROXY_KEY_PATH=~/.yaak-proxy/ca-key.pem
+# TRANSPARENT_PROXY_CA_PATH=~/.yaak-proxy/certs/ca.crt
+# TRANSPARENT_PROXY_KEY_PATH=~/.yaak-proxy/certs/ca.key

--- a/src/backend/config/config.go
+++ b/src/backend/config/config.go
@@ -58,8 +58,8 @@ type Config struct {
 // DefaultConfig returns the default configuration
 func DefaultConfig() *Config {
 	homeDir, _ := os.UserHomeDir()
-	caPath := filepath.Join(homeDir, ".yaak-proxy", "ca-cert.pem")
-	keyPath := filepath.Join(homeDir, ".yaak-proxy", "ca-key.pem")
+	caPath := filepath.Join(homeDir, ".yaak-proxy", "certs", "ca.crt")
+	keyPath := filepath.Join(homeDir, ".yaak-proxy", "certs", "ca.key")
 
 	return &Config{
 		OpenAIBaseURL: "https://api.openai.com/v1",

--- a/src/backend/server/server.go
+++ b/src/backend/server/server.go
@@ -457,7 +457,7 @@ func (s *Server) handleCACert(w http.ResponseWriter, r *http.Request) {
 	caPath := s.config.Proxy.CAPath
 	if caPath == "" {
 		homeDir, _ := os.UserHomeDir()
-		caPath = filepath.Join(homeDir, ".yaak-proxy", "ca-cert.pem")
+		caPath = filepath.Join(homeDir, ".yaak-proxy", "certs", "ca.crt")
 	}
 
 	data, err := os.ReadFile(caPath)


### PR DESCRIPTION
PR fixes the issue below. I fixed the location of the created certs instead of updating the text. The subdirectory looked more appropriate.

<img width="946" height="426" alt="Screenshot 2026-01-08 at 12 11 44 PM" src="https://github.com/user-attachments/assets/adc4fd41-8492-4d1b-871e-83830093cf22" />
