### PR TITLE
store tour in config, block tour until t&c completed

### DIFF
--- a/src/frontend/src/components/privacy-proxy-ui.tsx
+++ b/src/frontend/src/components/privacy-proxy-ui.tsx
@@ -169,7 +169,8 @@ export default function PrivacyProxyUI() {
 
   // Product tour
   const { startTour, isTourActive, cancelTour } = useTour(
-    welcomeModalJustClosed
+    welcomeModalJustClosed,
+    !termsRequireAcceptance
   );
 
   // Fixed Go server address - always call the Go server at this address

--- a/src/frontend/src/electron/electron-main.js
+++ b/src/frontend/src/electron/electron-main.js
@@ -1171,6 +1171,42 @@ ipcMain.handle("set-welcome-dismissed", async (event, dismissed) => {
   }
 });
 
+ipcMain.handle("get-tour-completed", async () => {
+  try {
+    const storagePath = getStoragePath();
+    if (!fs.existsSync(storagePath)) {
+      return false;
+    }
+
+    const data = fs.readFileSync(storagePath, "utf8");
+    const config = JSON.parse(data);
+    return config.tourCompleted || false;
+  } catch (error) {
+    console.error("Error reading tour completed flag:", error);
+    return false;
+  }
+});
+
+ipcMain.handle("set-tour-completed", async (event, completed) => {
+  try {
+    const storagePath = getStoragePath();
+    let config = {};
+
+    if (fs.existsSync(storagePath)) {
+      const data = fs.readFileSync(storagePath, "utf8");
+      config = JSON.parse(data);
+    }
+
+    config.tourCompleted = !!completed;
+
+    fs.writeFileSync(storagePath, JSON.stringify(config, null, 2), "utf8");
+    return { success: true };
+  } catch (error) {
+    console.error("Error saving tour completed flag:", error);
+    return { success: false, error: error.message };
+  }
+});
+
 // Model directory management
 ipcMain.handle("select-model-directory", async () => {
   const { dialog } = require("electron");

--- a/src/frontend/src/electron/electron-preload.js
+++ b/src/frontend/src/electron/electron-preload.js
@@ -134,6 +134,15 @@ contextBridge.exposeInMainWorld("electronAPI", {
     ipcRenderer.removeAllListeners("open-tour");
   },
 
+  // Tour completed flag
+  getTourCompleted: async () => {
+    return await ipcRenderer.invoke("get-tour-completed");
+  },
+
+  setTourCompleted: async (completed) => {
+    return await ipcRenderer.invoke("set-tour-completed", completed);
+  },
+
   // Model directory management
   selectModelDirectory: async () => {
     return await ipcRenderer.invoke("select-model-directory");

--- a/src/frontend/src/electron/electron.d.ts
+++ b/src/frontend/src/electron/electron.d.ts
@@ -48,6 +48,12 @@ interface ElectronAPI {
   setWelcomeDismissed: (
     dismissed: boolean
   ) => Promise<{ success: boolean; error?: string }>;
+  // Tour completed flag
+  getTourCompleted: () => Promise<boolean>;
+  setTourCompleted: (
+    completed: boolean
+  ) => Promise<{ success: boolean; error?: string }>;
+
   // Model directory settings
   getModelDirectory: () => Promise<string | null>;
   setModelDirectory: (


### PR DESCRIPTION
![ScreenRecording2026-02-09at5 14 13PM-ezgif com-video-to-gif-converter](https://github.com/user-attachments/assets/19a30cd9-5141-4700-96d9-0afd353505cd)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Product tour completion status is now persisted across application sessions
  * Tours will only initialize when terms of service have been accepted
  * Enhanced tour state management for improved user onboarding experience

<!-- end of auto-generated comment: release notes by coderabbit.ai -->