### PR TITLE
Contributor License Agreement (CLA) workflow

### DIFF
--- a/.github/cla/contributor_license_agreement.md
+++ b/.github/cla/contributor_license_agreement.md
@@ -1,0 +1,59 @@
+![Dataiku Logo](https://www.dataiku.com/wp-content/uploads/2025/04/DKU_LOGO_Teal.svg)
+
+# **Dataiku Individual Contributor License Agreement**
+
+Thank you for your interest in contributing to open source projects managed or sponsored by Dataiku (“**Dataiku**”).
+By submitting a Contribution to a Dataiku open source project, you agree to the terms of this Individual Contributor License Agreement (“**Agreement**”). This Agreement is intended to protect both you as a contributor and Dataiku as the project steward, without limiting your rights to use your own Contributions for any other purpose.
+
+## 1. Definitions
+“**You**” or “**Your**” means the individual copyright owner or the legal entity authorized by the copyright owner that is entering into this Agreement with Dataiku. If You are acting on behalf of a legal entity, “**You**” includes that entity and all entities that control, are controlled by, or are under common control with it. For purposes of this definition, “control” means direct or indirect ownership of more than fifty percent (50%) of the voting power or equity interests, or the power to direct management or policies.
+“**Contribution**” means any original work of authorship, including any modifications or additions to an existing work, that is intentionally submitted by You to Dataiku for inclusion in, or documentation of, any software, documentation, or other materials managed or distributed by Dataiku (the “**Project**”). A Contribution is considered “**submitted**” when communicated to Dataiku or its representatives through any electronic, verbal, or written means, including but not limited to source code repositories, issue trackers, mailing lists, or code review tools managed by or on behalf of Dataiku, unless You clearly mark the communication as “Not a Contribution.”
+
+## 2. Scope of Agreement
+This Agreement applies to all Contributions submitted by You to Dataiku, whether submitted before or after the date You first accept this Agreement, unless explicitly stated otherwise in writing by Dataiku.
+
+## 3. Grant of Copyright License
+Subject to the terms and conditions of this Agreement, and to the extent permitted by applicable law, You hereby grant to Dataiku and to recipients of software distributed by Dataiku a perpetual, worldwide, non-exclusive, royalty-free, irrevocable copyright license to: reproduce; prepare derivative works of; publicly display; publicly perform; sublicense; and distribute Your Contributions and any derivative works thereof.
+
+## 4. Grant of Patent License
+Subject to the terms and conditions of this Agreement, and to the extent permitted by applicable law, You hereby grant to Dataiku and to recipients of software distributed by Dataiku a perpetual, worldwide, non-exclusive, royalty-free, irrevocable patent license to make, have made, use, offer to sell, sell, import, and otherwise transfer the Contribution, where such license applies only to patent claims licensable by You that are necessarily infringed by Your Contribution alone or by its combination with the Project to which it was submitted. If You institute patent litigation against any entity (including a cross-claim or counterclaim) alleging that a Contribution or the Project infringes a patent, any patent licenses granted to You under this Agreement for that Contribution or Project shall terminate as of the date such litigation is filed.
+
+## 5. Ownership and Rights Retained
+Except for the licenses expressly granted in this Agreement, You retain all right, title, and interest in and to Your Contributions. Nothing in this Agreement limits Your right to use, modify, distribute, sublicense, or commercialize Your Contributions or derivative works thereof, subject to applicable open source licenses.
+
+## 6. Contributor Representations and Authority
+You represent and warrant that:
+a. You are legally entitled to grant the licenses set out in this Agreement;
+b. Each Contribution is Your original work, except for any third-party materials properly disclosed in accordance with this Agreement;
+c. If Your employer, client, or any other entity has or may have intellectual property rights in Your Contributions, You have obtained all necessary permissions, waivers, or authorizations to submit the Contributions and grant the licenses described herein;
+d. If You are acting on behalf of a legal entity, You have the authority to bind that entity to the terms of this Agreement.
+
+## 7. Contributions on Behalf of Third Parties
+If You submit material that is not Your original creation, You must retain all applicable copyright and license notices; clearly identify the third-party source and applicable license or restriction; and conspicuously mark the submission as: “Submitted on behalf of a third party: [name].”.
+
+## 8. Duty to Disclose and Notify
+You agree to promptly notify Dataiku if You become aware of any facts or circumstances that would make any representation or warranty in this Agreement inaccurate, incomplete, or misleading, including with respect to third-party intellectual property rights.
+
+## 9. No Support Obligation
+You are not obligated to provide maintenance, support, updates, or enhancements for Your Contributions, unless You separately agree to do so in writing.
+
+## 10. Disclaimer of Warranty
+Unless required by applicable law or agreed to in writing, You provide Your Contributions on an “AS IS” basis, without warranties or conditions of any kind, whether express or implied, including warranties of merchantability, fitness for a particular purpose, title, or non-infringement.
+
+## 11. Public Nature of Contributions
+You acknowledge that Contributions are public and that a record of Contributions, including your name, username, email address, IP address, timestamps, and associated metadata, may be maintained for as long as necessary for Dataiku to establish, exercise, or defend legal rights, and may be publicly disclosed as part of the Project history, in accordance with applicable open source licenses, and to the extent permitted by applicable law.
+
+## 12. Governing Law and Jurisdiction
+
+12.1. This Agreement shall be governed by and construed in accordance with the laws of the state of New York, USA, without regard to conflict-of-laws principles. 
+
+12.2. Any dispute arising out of or in connection with this Agreement shall be subject to the exclusive jurisdiction of the courts of New York, New York.
+
+## 13. Entire Agreement; Severability
+
+This Agreement constitutes the entire agreement between You and Dataiku regarding Contributions and supersedes all prior or contemporaneous agreements or understandings relating to the same subject matter. 
+
+If any provision of this Agreement is held unenforceable, the remaining provisions shall remain in full force and effect.
+By submitting a Contribution, You acknowledge that You have read, understood, and agree to be bound by this Agreement.
+
+Last Updated: February 3rd, 2026

--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -1,0 +1,26 @@
+name: CLA Assistant
+on:
+  issue_comment:
+    types: [created]
+  pull_request_target:
+    types: [opened, synchronize, reopened]
+
+permissions:
+  actions: write
+  contents: write
+  pull-requests: write
+  statuses: write
+
+jobs:
+  cla:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: cla-assistant/github-action@ca4a40a7d1004f18d9960b404b97e5f30a505a08 # v2.6.1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PERSONAL_ACCESS_TOKEN: ${{ secrets.CLA_TOKEN }}
+        with:
+          path-to-signatures: ".github/cla/cla.json"
+          path-to-document: "https://github.com/dataiku/kiji-proxy/blob/main/.github/cla/CLA.md"
+          branch: "main"
+          allowlist: "bot*,dependabot*"


### PR DESCRIPTION
**Regarding the CLA workflow:**

If we can use a Gist on Github, a repo admin could set up the CLA from https://cla-assistant.io/ (built by SAP).

The setup looks like below (just with the correct repo and Gist)
<img width="1492" height="1119" alt="Screenshot 2026-02-11 at 2 16 47 PM" src="https://github.com/user-attachments/assets/ca248476-e485-4cb5-87b8-69dccf7a782d" />
<img width="1428" height="1121" alt="Screenshot 2026-02-11 at 2 16 53 PM" src="https://github.com/user-attachments/assets/d90b5138-fcc0-4554-b874-473e06ad7eee" />

**An alternative is this PR:**
It uses https://github.com/cla-assistant/cla-assistant but runs the entire signing without the need for Gist. The text can be loaded from the repo. Downside: 1) It needs a write token to write the user information to a file, and 2) the file with the CLA "signature information" is part of the repo (Name and email are visible through their commits anyway) (admin needed). We could also write to a private repo that only contains the CLA signature information, but we would need to set up another repository (admin needed). 

@pbertin Which option do you prefer?
1. External service (admin needed for the setup)
2. This PR and the information are stored in this repo (admin needed for the token creation)
3. This PR with the data been pushed to a separate, private repository (admin needed for the token and repo creation)