### PR TITLE
Add auto-update support for macOS via GitHub Releases

### DIFF
--- a/.github/workflows/release-dmg.yml
+++ b/.github/workflows/release-dmg.yml
@@ -193,18 +193,24 @@ jobs:
             fi
           done
 
-      - name: Upload DMG as Artifact
+      - name: Upload Build Artifacts
         uses: actions/upload-artifact@v4
         with:
           name: kiji-privacy-proxy-${{ steps.version.outputs.version }}-macos
-          path: src/frontend/release/*.dmg
+          path: |
+            src/frontend/release/*.dmg
+            src/frontend/release/*.zip
+            src/frontend/release/latest-mac.yml
           retention-days: 90
 
       - name: Upload to GitHub Release
         if: startsWith(github.ref, 'refs/tags/v') || github.event.inputs.create_release == 'true'
         uses: softprops/action-gh-release@v2
         with:
-          files: src/frontend/release/*.dmg
+          files: |
+            src/frontend/release/*.dmg
+            src/frontend/release/*.zip
+            src/frontend/release/latest-mac.yml
           draft: false
           prerelease: ${{ contains(github.ref, '-beta') || contains(github.ref, '-alpha') || contains(github.ref, '-rc') }}
           fail_on_unmatched_files: true

--- a/package-lock.json
+++ b/package-lock.json
@@ -69,6 +69,7 @@
       "version": "7.28.5",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.27.1",
         "@babel/generator": "^7.28.5",
@@ -2083,7 +2084,6 @@
       "dev": true,
       "license": "BSD-2-Clause",
       "optional": true,
-      "peer": true,
       "dependencies": {
         "cross-dirname": "^0.1.0",
         "debug": "^4.3.4",
@@ -2103,7 +2103,6 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
-      "peer": true,
       "dependencies": {
         "graceful-fs": "^4.2.0",
         "jsonfile": "^6.0.1",
@@ -2118,7 +2117,6 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
-      "peer": true,
       "dependencies": {
         "universalify": "^2.0.0"
       },
@@ -2131,7 +2129,6 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
-      "peer": true,
       "engines": {
         "node": ">= 10.0.0"
       }
@@ -3144,6 +3141,7 @@
     "node_modules/@opentelemetry/api": {
       "version": "1.9.0",
       "license": "Apache-2.0",
+      "peer": true,
       "engines": {
         "node": ">=8.0.0"
       }
@@ -3161,6 +3159,7 @@
     "node_modules/@opentelemetry/context-async-hooks": {
       "version": "2.2.0",
       "license": "Apache-2.0",
+      "peer": true,
       "engines": {
         "node": "^18.19.0 || >=20.6.0"
       },
@@ -3171,6 +3170,7 @@
     "node_modules/@opentelemetry/core": {
       "version": "2.2.0",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@opentelemetry/semantic-conventions": "^1.29.0"
       },
@@ -3184,6 +3184,7 @@
     "node_modules/@opentelemetry/instrumentation": {
       "version": "0.208.0",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@opentelemetry/api-logs": "0.208.0",
         "import-in-the-middle": "^2.0.0",
@@ -3523,6 +3524,7 @@
     "node_modules/@opentelemetry/resources": {
       "version": "2.2.0",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@opentelemetry/core": "2.2.0",
         "@opentelemetry/semantic-conventions": "^1.29.0"
@@ -3537,6 +3539,7 @@
     "node_modules/@opentelemetry/sdk-trace-base": {
       "version": "2.2.0",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@opentelemetry/core": "2.2.0",
         "@opentelemetry/resources": "2.2.0",
@@ -3552,6 +3555,7 @@
     "node_modules/@opentelemetry/semantic-conventions": {
       "version": "1.38.0",
       "license": "Apache-2.0",
+      "peer": true,
       "engines": {
         "node": ">=14"
       }
@@ -4207,6 +4211,7 @@
       "version": "18.3.27",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/prop-types": "*",
         "csstype": "^3.2.2"
@@ -4349,6 +4354,7 @@
       "version": "8.52.0",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.52.0",
         "@typescript-eslint/types": "8.52.0",
@@ -4746,6 +4752,7 @@
     "node_modules/acorn": {
       "version": "8.15.0",
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -4791,6 +4798,7 @@
       "version": "6.12.6",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
         "fast-json-stable-stringify": "^2.0.0",
@@ -5125,7 +5133,6 @@
     },
     "node_modules/argparse": {
       "version": "2.0.1",
-      "dev": true,
       "license": "Python-2.0"
     },
     "node_modules/array-buffer-byte-length": {
@@ -5604,6 +5611,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -5679,7 +5687,6 @@
     },
     "node_modules/builder-util-runtime": {
       "version": "9.5.1",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "debug": "^4.3.4",
@@ -6289,8 +6296,7 @@
       "version": "0.1.0",
       "dev": true,
       "license": "MIT",
-      "optional": true,
-      "peer": true
+      "optional": true
     },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
@@ -6673,6 +6679,7 @@
       "version": "26.7.0",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "app-builder-lib": "26.7.0",
         "builder-util": "26.4.1",
@@ -7048,12 +7055,62 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/electron-updater": {
+      "version": "6.7.3",
+      "resolved": "https://registry.npmjs.org/electron-updater/-/electron-updater-6.7.3.tgz",
+      "integrity": "sha512-EgkT8Z9noqXKbwc3u5FkJA+r48jwZ5DTUiOkJMOTEEH//n5Am6wfQGz7nvSFEA2oIAMv9jRzn5JKTyWeSKOPgg==",
+      "license": "MIT",
+      "dependencies": {
+        "builder-util-runtime": "9.5.1",
+        "fs-extra": "^10.1.0",
+        "js-yaml": "^4.1.0",
+        "lazy-val": "^1.0.5",
+        "lodash.escaperegexp": "^4.1.2",
+        "lodash.isequal": "^4.5.0",
+        "semver": "~7.7.3",
+        "tiny-typed-emitter": "^2.1.0"
+      }
+    },
+    "node_modules/electron-updater/node_modules/fs-extra": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.1.0.tgz",
+      "integrity": "sha512-oRXApq54ETRj4eMiFzGnHWGy+zo5raudjuxN0b8H7s/RU2oW0Wvsx9O0ACRN/kRq9E8Vu/ReskGB5o3ji+FzHQ==",
+      "license": "MIT",
+      "dependencies": {
+        "graceful-fs": "^4.2.0",
+        "jsonfile": "^6.0.1",
+        "universalify": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/electron-updater/node_modules/jsonfile": {
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.2.0.tgz",
+      "integrity": "sha512-FGuPw30AdOIUTRMC2OMRtQV+jkVj2cfPqSeWXv1NEAJ1qZ5zb1X6z1mFhbfOB/iy3ssJCD+3KuZ8r8C3uVFlAg==",
+      "license": "MIT",
+      "dependencies": {
+        "universalify": "^2.0.0"
+      },
+      "optionalDependencies": {
+        "graceful-fs": "^4.1.6"
+      }
+    },
+    "node_modules/electron-updater/node_modules/universalify": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
+      "integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
     "node_modules/electron-winstaller": {
       "version": "5.4.0",
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@electron/asar": "^3.2.1",
         "debug": "^4.1.1",
@@ -7377,6 +7434,7 @@
       "version": "9.39.2",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -8470,7 +8528,6 @@
     },
     "node_modules/graceful-fs": {
       "version": "4.2.11",
-      "dev": true,
       "license": "ISC"
     },
     "node_modules/handle-thing": {
@@ -9625,7 +9682,6 @@
     },
     "node_modules/js-yaml": {
       "version": "4.1.1",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "argparse": "^2.0.1"
@@ -9735,7 +9791,6 @@
     },
     "node_modules/lazy-val": {
       "version": "1.0.5",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/levn": {
@@ -9833,6 +9888,19 @@
     "node_modules/lodash.debounce": {
       "version": "4.0.8",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/lodash.escaperegexp": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/lodash.escaperegexp/-/lodash.escaperegexp-4.1.2.tgz",
+      "integrity": "sha512-TM9YBvyC84ZxE3rgfefxUWiQKLilstD6k7PTGt6wfbtXF8ixIJLOL3VYyV/z+ZiPLsVxAsKAFVwWlWeb2Y8Yyw==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isequal": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/lodash.isequal/-/lodash.isequal-4.5.0.tgz",
+      "integrity": "sha512-pDo3lu8Jhfjqls6GkMgpahsF9kCyayhgykjyLMNFTKWrpVdAQtYyB4muAMWozBB4ig/dtWAmsMxLEI8wuz+DYQ==",
+      "deprecated": "This package is deprecated. Use require('node:util').isDeepStrictEqual instead.",
       "license": "MIT"
     },
     "node_modules/lodash.merge": {
@@ -10250,7 +10318,6 @@
       "version": "0.5.6",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "minimist": "^1.2.6"
       },
@@ -11084,6 +11151,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
@@ -11231,7 +11299,6 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
-      "peer": true,
       "dependencies": {
         "commander": "^9.4.0"
       },
@@ -11247,7 +11314,6 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
-      "peer": true,
       "engines": {
         "node": "^12.20.0 || >=14"
       }
@@ -11484,6 +11550,7 @@
     "node_modules/react": {
       "version": "18.3.1",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0"
       },
@@ -11494,6 +11561,7 @@
     "node_modules/react-dom": {
       "version": "18.3.1",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0",
         "scheduler": "^0.23.2"
@@ -11853,7 +11921,6 @@
       "version": "2.6.3",
       "dev": true,
       "license": "ISC",
-      "peer": true,
       "dependencies": {
         "glob": "^7.1.3"
       },
@@ -11998,7 +12065,6 @@
     },
     "node_modules/sax": {
       "version": "1.4.4",
-      "dev": true,
       "license": "BlueOak-1.0.0",
       "engines": {
         "node": ">=11.0.0"
@@ -12033,6 +12099,7 @@
       "version": "8.17.1",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "fast-uri": "^3.0.1",
@@ -12079,7 +12146,6 @@
     },
     "node_modules/semver": {
       "version": "7.7.3",
-      "dev": true,
       "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
@@ -12872,7 +12938,6 @@
       "version": "0.9.4",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "mkdirp": "^0.5.1",
         "rimraf": "~2.6.2"
@@ -13024,6 +13089,12 @@
         "semver": "bin/semver"
       }
     },
+    "node_modules/tiny-typed-emitter": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/tiny-typed-emitter/-/tiny-typed-emitter-2.1.0.tgz",
+      "integrity": "sha512-qVtvMxeXbVej0cQWKqVSSAHmKZEHAvxdF8HEUBFWts8h+xEo5m/lEiPakuyZ3BnCBjOD8i24kzNOiOLLgsSxhA==",
+      "license": "MIT"
+    },
     "node_modules/tinyglobby": {
       "version": "0.2.15",
       "dev": true,
@@ -13059,6 +13130,7 @@
       "version": "4.0.3",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -13136,7 +13208,8 @@
     "node_modules/tslib": {
       "version": "2.8.1",
       "dev": true,
-      "license": "0BSD"
+      "license": "0BSD",
+      "peer": true
     },
     "node_modules/tsyringe": {
       "version": "4.10.0",
@@ -13249,6 +13322,7 @@
     "node_modules/typescript": {
       "version": "5.9.3",
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -13471,6 +13545,7 @@
       "version": "5.104.1",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/eslint-scope": "^3.7.7",
         "@types/estree": "^1.0.8",
@@ -13518,6 +13593,7 @@
       "version": "5.1.4",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@discoveryjs/json-ext": "^0.5.0",
         "@webpack-cli/configtest": "^2.1.1",
@@ -14011,6 +14087,7 @@
       "version": "4.3.6",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }
@@ -14028,11 +14105,12 @@
     },
     "src/frontend": {
       "name": "kiji-privacy-proxy",
-      "version": "0.4.1",
+      "version": "0.4.2",
       "dependencies": {
         "@sentry/electron": "^7.5.0",
         "@types/dompurify": "^3.0.5",
         "dompurify": "^3.3.1",
+        "electron-updater": "^6.7.3",
         "express": "^4.18.0",
         "http-proxy-middleware": "^2.0.6",
         "lucide-react": "^0.263.1",

--- a/src/frontend/package.json
+++ b/src/frontend/package.json
@@ -25,6 +25,7 @@
     "@sentry/electron": "^7.5.0",
     "@types/dompurify": "^3.0.5",
     "dompurify": "^3.3.1",
+    "electron-updater": "^6.7.3",
     "express": "^4.18.0",
     "http-proxy-middleware": "^2.0.6",
     "lucide-react": "^0.263.1",
@@ -69,6 +70,11 @@
     "electronVersion": "28.3.3",
     "npmRebuild": false,
     "icon": "assets/icon.png",
+    "publish": {
+      "provider": "github",
+      "owner": "dataiku",
+      "repo": "kiji-proxy"
+    },
     "directories": {
       "output": "release"
     },
@@ -109,7 +115,8 @@
     "mac": {
       "category": "public.app-category.utilities",
       "target": [
-        "dmg"
+        "dmg",
+        "zip"
       ],
       "hardenedRuntime": true,
       "gatekeeperAssess": false,


### PR DESCRIPTION
## What

Adds automatic update functionality to the Electron app using `electron-updater`.
When a new version is published as a GitHub Release, running instances will
detect it, download the update in the background, and prompt the user to restart.

## Changes

- **`src/frontend/package.json`**: Added `electron-updater` dependency, `publish`
  config pointing to `dataiku/kiji-proxy`, and `zip` to macOS build targets
  (electron-updater uses the `.zip` for applying updates; the `.dmg` remains for
  first-time installs)
- **`src/frontend/src/electron/electron-main.js`**: Auto-update lifecycle —
  checks for updates on launch, re-checks hourly, downloads in background,
  prompts user to restart when ready. Skipped in dev mode.
- **`.github/workflows/release-dmg.yml`**: Upload `.zip` and `latest-mac.yml`
  to GitHub Releases alongside the `.dmg`

## How it works

1. Tag push triggers CI, which builds `.dmg` + `.zip` + `latest-mac.yml`
2. All three artifacts are uploaded to the GitHub Release
3. Running app checks `latest-mac.yml` via GitHub Releases API on startup
   (and every hour)
4. If a newer version exists, the `.zip` is downloaded in the background
5. User is prompted to restart — `quitAndInstall()` swaps the app in place

## Notes

- Code signing (already configured via `CSC_LINK`) is required for macOS
  auto-update to work. Unsigned builds will be blocked by Gatekeeper.
- Notarization is not enabled (as before).
