### PR TITLE
fixes count of PII in response

### DIFF
--- a/src/frontend/src/components/privacy-proxy-ui.tsx
+++ b/src/frontend/src/components/privacy-proxy-ui.tsx
@@ -67,6 +67,7 @@ export default function PrivacyProxyUI() {
     maskedInput,
     isProcessing,
     detectedEntities,
+    responseDetectedEntities,
     averageConfidence,
     highlightedInputOriginalHTML,
     highlightedInputMaskedHTML,
@@ -452,7 +453,7 @@ export default function PrivacyProxyUI() {
                   />
                   <div className="mt-2">
                     <p className="text-sm font-semibold text-slate-700">
-                      {detectedEntities.length} fake PIIs received
+                      {responseDetectedEntities.length} fake PIIs received
                     </p>
                   </div>
                 </div>
@@ -473,7 +474,7 @@ export default function PrivacyProxyUI() {
                   />
                   <div className="mt-2">
                     <p className="text-sm font-semibold text-green-600">
-                      {detectedEntities.length} PII restored
+                      {responseDetectedEntities.length} PII restored
                     </p>
                   </div>
                 </div>

--- a/src/frontend/src/hooks/useProxySubmit.ts
+++ b/src/frontend/src/hooks/useProxySubmit.ts
@@ -117,6 +117,12 @@ export function useProxySubmit({
     [finalOutput, detectedEntities]
   );
 
+  const responseDetectedEntities = useMemo(
+    () =>
+      detectedEntities.filter((entity) => maskedOutput.includes(entity.token)),
+    [detectedEntities, maskedOutput]
+  );
+
   const handleSubmit = useCallback(async () => {
     if (!inputData.trim()) return;
 
@@ -260,6 +266,7 @@ export function useProxySubmit({
     finalOutput,
     isProcessing,
     detectedEntities,
+    responseDetectedEntities,
     averageConfidence,
     highlightedInputOriginalHTML,
     highlightedInputMaskedHTML,


### PR DESCRIPTION
Before the fix (number originate from the request):

<img width="1336" height="670" alt="Screenshot 2026-02-14 at 4 12 56 PM" src="https://github.com/user-attachments/assets/bcb4a369-c2c5-4a43-bbe2-66e791aa118a" />

Now (number originates from the response):
<img width="1310" height="655" alt="Screenshot 2026-02-14 at 4 23 03 PM" src="https://github.com/user-attachments/assets/f964ff3a-bce6-4bc8-a56b-9f5fb3a49205" />
