### PR TITLE
fix: bump go version to use go.mod and mise tool version specified

### DIFF
--- a/.changeset/eight-bananas-slide.md
+++ b/.changeset/eight-bananas-slide.md
@@ -1,0 +1,5 @@
+---
+"kiji-privacy-proxy": patch
+---
+
+fix linux builds

--- a/.github/workflows/lint-and-test.yml
+++ b/.github/workflows/lint-and-test.yml
@@ -45,7 +45,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v6
         with:
-          go-version: "1.25"
+          go-version-file: go.mod
 
       - name: golangci-lint
         uses: golangci/golangci-lint-action@1e7e51e771db61008b38414a730f564565cf7c20 # v9.2.0
@@ -62,7 +62,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v6
         with:
-          go-version: "1.25"
+          go-version-file: go.mod
 
       - name: Cache tokenizers library
         id: cache-tokenizers

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -60,7 +60,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v6
         with:
-          go-version: "1.24"
+          go-version: "1.25"
           cache: false
 
       - name: Setup Python
@@ -222,7 +222,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v6
         with:
-          go-version: "1.24"
+          go-version: "1.25"
 
       - name: Setup Rust
         uses: dtolnay/rust-toolchain@4be9e76fd7c4901c61fb841f559994984270fce7 # stable

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -60,7 +60,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v6
         with:
-          go-version: "1.25"
+          go-version-file: go.mod
           cache: false
 
       - name: Setup Python
@@ -222,7 +222,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v6
         with:
-          go-version: "1.25"
+          go-version-file: go.mod
 
       - name: Setup Rust
         uses: dtolnay/rust-toolchain@4be9e76fd7c4901c61fb841f559994984270fce7 # stable


### PR DESCRIPTION
I was a bit surprised by this, since in my mind we had always this version:

- [link mise](https://github.com/dataiku/kiji-proxy/blob/42eb3c5c4131e6ed1b20ea7964e3c44ced348024/mise.toml#L2)

also dependabot was using the same version:

- [go.mod](https://github.com/dataiku/kiji-proxy/blob/42eb3c5c4131e6ed1b20ea7964e3c44ced348024/go.mod#L3)

anyway, this should release the build and release process and follow go.mod as a single source of truth