### PR TITLE
feat: enable notarization using App Store Connect API key

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,22 +34,21 @@ jobs:
           MISSING=""
           [ -z "$CSC_LINK" ] && MISSING="$MISSING CSC_LINK"
           [ -z "$CSC_KEY_PASSWORD" ] && MISSING="$MISSING CSC_KEY_PASSWORD"
-          # Notarization is currently disabled; uncomment these checks when re-enabled:
-          # [ -z "$APPLE_ID" ] && MISSING="$MISSING APPLE_ID"
-          # [ -z "$APPLE_APP_SPECIFIC_PASSWORD" ] && MISSING="$MISSING APPLE_APP_SPECIFIC_PASSWORD"
-          # [ -z "$APPLE_TEAM_ID" ] && MISSING="$MISSING APPLE_TEAM_ID"
+          [ -z "$APPLE_API_KEY" ] && MISSING="$MISSING APPLE_API_KEY"
+          [ -z "$APPLE_API_KEY_ID" ] && MISSING="$MISSING APPLE_API_KEY_ID"
+          [ -z "$APPLE_API_ISSUER" ] && MISSING="$MISSING APPLE_API_ISSUER"
           if [ -n "$MISSING" ]; then
             echo "::error::Missing required environment secrets:$MISSING"
             echo "Ensure the 'DMG Build Environment' environment is configured with all required secrets."
             exit 1
           fi
-          echo "All signing secrets are set."
+          echo "All signing and notarization secrets are set."
         env:
           CSC_LINK: ${{ secrets.CSC_LINK }}
           CSC_KEY_PASSWORD: ${{ secrets.CSC_KEY_PASSWORD }}
-          APPLE_ID: ${{ secrets.APPLE_ID }}
-          APPLE_APP_SPECIFIC_PASSWORD: ${{ secrets.APPLE_APP_SPECIFIC_PASSWORD }}
-          APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
+          APPLE_API_KEY: ${{ secrets.APPLE_API_KEY }}
+          APPLE_API_KEY_ID: ${{ secrets.APPLE_API_KEY_ID }}
+          APPLE_API_ISSUER: ${{ secrets.APPLE_API_ISSUER }}
 
       - name: Checkout Repository
         uses: actions/checkout@v6
@@ -160,9 +159,9 @@ jobs:
         env:
           CSC_LINK: ${{ secrets.CSC_LINK }}
           CSC_KEY_PASSWORD: ${{ secrets.CSC_KEY_PASSWORD }}
-          APPLE_ID: ${{ secrets.APPLE_ID }}
-          APPLE_APP_SPECIFIC_PASSWORD: ${{ secrets.APPLE_APP_SPECIFIC_PASSWORD }}
-          APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
+          APPLE_API_KEY: ${{ secrets.APPLE_API_KEY }}
+          APPLE_API_KEY_ID: ${{ secrets.APPLE_API_KEY_ID }}
+          APPLE_API_ISSUER: ${{ secrets.APPLE_API_ISSUER }}
 
       - name: Rename DMG with Version
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -154,12 +154,20 @@ jobs:
           cd src/frontend
           npm ci
 
+      - name: Write Apple API key to file
+        run: |
+          mkdir -p "$RUNNER_TEMP/apple"
+          echo "$APPLE_API_KEY" > "$RUNNER_TEMP/apple/AuthKey.p8"
+          chmod 600 "$RUNNER_TEMP/apple/AuthKey.p8"
+        env:
+          APPLE_API_KEY: ${{ secrets.APPLE_API_KEY }}
+
       - name: Build DMG
         run: make build-dmg
         env:
           CSC_LINK: ${{ secrets.CSC_LINK }}
           CSC_KEY_PASSWORD: ${{ secrets.CSC_KEY_PASSWORD }}
-          APPLE_API_KEY: ${{ secrets.APPLE_API_KEY }}
+          APPLE_API_KEY: ${{ runner.temp }}/apple/AuthKey.p8
           APPLE_API_KEY_ID: ${{ secrets.APPLE_API_KEY_ID }}
           APPLE_API_ISSUER: ${{ secrets.APPLE_API_ISSUER }}
 

--- a/src/frontend/package.json
+++ b/src/frontend/package.json
@@ -1,5 +1,4 @@
 {
-  "_note": "TODO: Enable notarization by adding \"afterSign\": \"../../src/scripts/notarize.js\" to the build config (requires Developer ID Application certificate)",
   "name": "kiji-privacy-proxy",
   "productName": "Kiji Privacy Proxy",
   "version": "0.4.11",
@@ -118,6 +117,7 @@
       "minimumSystemVersion": "10.13"
     },
     "afterPack": "../../src/scripts/remove-locales.js",
+    "afterSign": "../../src/scripts/notarize.js",
     "dmg": {
       "title": "${productName} ${version}",
       "background": "assets/dmg-background.png",

--- a/src/frontend/package.json
+++ b/src/frontend/package.json
@@ -117,7 +117,6 @@
       "minimumSystemVersion": "10.13"
     },
     "afterPack": "../../src/scripts/remove-locales.js",
-    "afterSign": "../../src/scripts/notarize.js",
     "dmg": {
       "title": "${productName} ${version}",
       "background": "assets/dmg-background.png",

--- a/src/scripts/build_dmg.sh
+++ b/src/scripts/build_dmg.sh
@@ -411,9 +411,10 @@ fi
 # When CSC_LINK is set, electron-builder will automatically sign with the Developer ID certificate.
 # When CSC_LINK is not set, electron-builder falls back to ad-hoc signing.
 echo "Running electron-builder..."
-# Unset legacy Apple ID credentials so electron-builder's built-in notarization
-# does not trigger. Notarization is handled by the afterSign hook (notarize.js)
-# using the APPLE_API_KEY / APPLE_API_KEY_ID / APPLE_API_ISSUER env vars instead.
+# Unset legacy Apple ID credentials to prevent electron-builder from attempting
+# the deprecated password-based notarization path. API key notarization
+# (APPLE_API_KEY file path + APPLE_API_KEY_ID + APPLE_API_ISSUER) is handled
+# natively by electron-builder v26+ when those env vars are set.
 unset APPLE_ID
 unset APPLE_APP_SPECIFIC_PASSWORD
 unset APPLE_TEAM_ID

--- a/src/scripts/build_dmg.sh
+++ b/src/scripts/build_dmg.sh
@@ -411,9 +411,9 @@ fi
 # When CSC_LINK is set, electron-builder will automatically sign with the Developer ID certificate.
 # When CSC_LINK is not set, electron-builder falls back to ad-hoc signing.
 echo "Running electron-builder..."
-# Unset Apple notarization credentials to prevent electron-builder's built-in
-# notarization from triggering automatically. Notarization is currently disabled
-# until a Developer ID Application certificate is configured.
+# Unset legacy Apple ID credentials so electron-builder's built-in notarization
+# does not trigger. Notarization is handled by the afterSign hook (notarize.js)
+# using the APPLE_API_KEY / APPLE_API_KEY_ID / APPLE_API_ISSUER env vars instead.
 unset APPLE_ID
 unset APPLE_APP_SPECIFIC_PASSWORD
 unset APPLE_TEAM_ID
@@ -500,7 +500,11 @@ echo "-----------------------------------"
 
 if [ -n "${CSC_LINK:-}" ]; then
     echo "✅ App was signed with Developer ID certificate by electron-builder"
-    echo "   Notarization was handled by afterSign hook (if credentials were provided)"
+    if [ -n "${APPLE_API_KEY:-}" ]; then
+        echo "✅ Notarization was handled by afterSign hook (APPLE_API_KEY set)"
+    else
+        echo "⚠️  Notarization skipped (APPLE_API_KEY not set)"
+    fi
 else
     echo "✅ App was ad-hoc signed with consistent identity and packaged into DMG"
 fi

--- a/src/scripts/notarize.js
+++ b/src/scripts/notarize.js
@@ -1,23 +1,44 @@
 const { notarize } = require("@electron/notarize");
+const path = require("path");
+const fs = require("fs");
+const os = require("os");
 
 exports.default = async function notarizing(context) {
   const { electronPlatformName, appOutDir } = context;
   if (electronPlatformName !== "darwin") return;
-  if (!process.env.APPLE_ID || !process.env.APPLE_APP_SPECIFIC_PASSWORD) {
-    console.log("Skipping notarization (no credentials)");
+
+  const apiKey = process.env.APPLE_API_KEY;
+  const apiKeyId = process.env.APPLE_API_KEY_ID;
+  const apiIssuer = process.env.APPLE_API_ISSUER;
+
+  if (!apiKey || !apiKeyId || !apiIssuer) {
+    console.log(
+      "Skipping notarization (APPLE_API_KEY, APPLE_API_KEY_ID, and APPLE_API_ISSUER are all required)"
+    );
     return;
   }
 
   const appName = context.packager.appInfo.productName;
   const appPath = `${appOutDir}/${appName}.app`;
 
-  console.log(`Notarizing ${appPath}...`);
-  await notarize({
-    appBundleId: "com.kiji.proxy",
-    appPath,
-    appleId: process.env.APPLE_ID,
-    appleIdPassword: process.env.APPLE_APP_SPECIFIC_PASSWORD,
-    teamId: process.env.APPLE_TEAM_ID,
-  });
-  console.log("Notarization complete.");
+  // notarytool requires the API key as a .p8 file path, not inline content.
+  // Write the secret value to a temp file with restricted permissions.
+  const tmpKeyPath = path.join(os.tmpdir(), `apple-api-key-${Date.now()}.p8`);
+  try {
+    fs.writeFileSync(tmpKeyPath, apiKey, { mode: 0o600 });
+    console.log(`Notarizing ${appPath}...`);
+    await notarize({
+      tool: "notarytool",
+      appBundleId: "com.kiji.proxy",
+      appPath,
+      appleApiKey: tmpKeyPath,
+      appleApiKeyId: apiKeyId,
+      appleApiIssuer: apiIssuer,
+    });
+    console.log("Notarization complete.");
+  } finally {
+    try {
+      fs.unlinkSync(tmpKeyPath);
+    } catch (_) {}
+  }
 };

--- a/src/scripts/notarize.js
+++ b/src/scripts/notarize.js
@@ -1,17 +1,17 @@
 const { notarize } = require("@electron/notarize");
-const path = require("path");
 const fs = require("fs");
 const os = require("os");
+const path = require("path");
 
 exports.default = async function notarizing(context) {
   const { electronPlatformName, appOutDir } = context;
   if (electronPlatformName !== "darwin") return;
 
-  const apiKey = process.env.APPLE_API_KEY;
+  const apiKeyInput = process.env.APPLE_API_KEY;
   const apiKeyId = process.env.APPLE_API_KEY_ID;
   const apiIssuer = process.env.APPLE_API_ISSUER;
 
-  if (!apiKey || !apiKeyId || !apiIssuer) {
+  if (!apiKeyInput || !apiKeyId || !apiIssuer) {
     console.log(
       "Skipping notarization (APPLE_API_KEY, APPLE_API_KEY_ID, and APPLE_API_ISSUER are all required)"
     );
@@ -21,24 +21,35 @@ exports.default = async function notarizing(context) {
   const appName = context.packager.appInfo.productName;
   const appPath = `${appOutDir}/${appName}.app`;
 
-  // notarytool requires the API key as a .p8 file path, not inline content.
-  // Write the secret value to a temp file with restricted permissions.
-  const tmpKeyPath = path.join(os.tmpdir(), `apple-api-key-${Date.now()}.p8`);
+  // APPLE_API_KEY can be either a file path (from CI) or raw .p8 content.
+  let keyFilePath;
+  let tmpKeyPath = null;
+
+  if (fs.existsSync(apiKeyInput)) {
+    keyFilePath = apiKeyInput;
+  } else {
+    // Raw key content — write to a temp file for notarytool.
+    tmpKeyPath = path.join(os.tmpdir(), `apple-api-key-${Date.now()}.p8`);
+    fs.writeFileSync(tmpKeyPath, apiKeyInput, { mode: 0o600 });
+    keyFilePath = tmpKeyPath;
+  }
+
   try {
-    fs.writeFileSync(tmpKeyPath, apiKey, { mode: 0o600 });
     console.log(`Notarizing ${appPath}...`);
     await notarize({
       tool: "notarytool",
       appBundleId: "com.kiji.proxy",
       appPath,
-      appleApiKey: tmpKeyPath,
+      appleApiKey: keyFilePath,
       appleApiKeyId: apiKeyId,
       appleApiIssuer: apiIssuer,
     });
     console.log("Notarization complete.");
   } finally {
-    try {
-      fs.unlinkSync(tmpKeyPath);
-    } catch (_) {}
+    if (tmpKeyPath) {
+      try {
+        fs.unlinkSync(tmpKeyPath);
+      } catch (_) {}
+    }
   }
 };


### PR DESCRIPTION
## Summary

- Rewrites `src/scripts/notarize.js` to use `notarytool` + API key method (`APPLE_API_KEY`, `APPLE_API_KEY_ID`, `APPLE_API_ISSUER`) instead of the deprecated Apple ID / app-specific password approach
- Wires `afterSign` into `src/frontend/package.json` so notarization actually runs during the electron-builder DMG packaging step (was only in a `_note` TODO comment before)
- Updates `.github/workflows/release.yml` to verify and pass the three new API key secrets instead of the old `APPLE_ID` / `APPLE_APP_SPECIFIC_PASSWORD` / `APPLE_TEAM_ID` secrets

## Test plan

- [x] Trigger the `Build and Release` workflow via `workflow_dispatch` and confirm the "Verify signing secrets" step passes with the new secrets set in the DMG Build Environment
- [x] Confirm the DMG build step completes and the notarize hook logs `Notarizing ...` and `Notarization complete.`
- [x] Download the resulting DMG artifact and verify it passes Gatekeeper (`spctl -a -v Kiji\ Privacy\ Proxy.app`)