### PR TITLE
fix: street name generator

### DIFF
--- a/src/backend/pii/generators/pii_generators.go
+++ b/src/backend/pii/generators/pii_generators.go
@@ -156,10 +156,7 @@ func StreetGenerator(rng *rand.Rand, original string) string {
 		"King Street", "Manor Road", "Park Lane", "The Crescent", "Green Lane",
 		"Mill Lane", "New Road", "Chapel Street", "West End", "North Terrace",
 	}
-	number := 100 + rng.Intn(9900)
-
-	street := streetNames[rng.Intn(len(streetNames))]
-	return fmt.Sprintf("%d %s", number, street)
+	return streetNames[rng.Intn(len(streetNames))]
 }
 
 // ZipCodeGenerator generates dummy zip codes

--- a/src/backend/pii/generators/pii_generators_test.go
+++ b/src/backend/pii/generators/pii_generators_test.go
@@ -130,10 +130,12 @@ func TestStreetGenerator(t *testing.T) {
 	rng := getTestRand(42)
 	result := StreetGenerator(rng, "")
 
-	// Check that result contains a number and street name
-	streetPattern := regexp.MustCompile(`^\d+ .+$`)
-	if !streetPattern.MatchString(result) {
-		t.Errorf("StreetGenerator returned invalid street format: %s", result)
+	if result == "" {
+		t.Errorf("StreetGenerator returned empty result")
+	}
+	streetPattern := regexp.MustCompile(`^\d`)
+	if streetPattern.MatchString(result) {
+		t.Errorf("StreetGenerator should not include a leading number: %s", result)
 	}
 }
 


### PR DESCRIPTION
## Summary
- `StreetGenerator` no longer prepends a random building number to its output; it now returns just the street name (e.g. `Pine Road`) so replacements align with the `STREET` entity type.
- Updated the corresponding unit test to assert the result is non-empty and does not start with a digit.

## Test plan
- [x] `go test ./pii/generators/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)