### PR TITLE
fix: show Unknown instead of masked value when entity label missing

### DIFF
--- a/chrome-extension/content.js
+++ b/chrome-extension/content.js
@@ -87,13 +87,16 @@
   }
 
   // Format a backend label ("CITY", "FIRST_NAME") as a user-facing string.
-  // Falls back to stripping angle brackets / index suffixes for legacy
-  // bracket-token responses like `<PERSON_1>`.
+  // Only parses the masked value as a label when it's a legacy bracket token
+  // like `<PERSON_1>`; modern masked values are realistic fakes (e.g. "25627"
+  // for a zipcode) and would otherwise be shown verbatim as the type.
   function formatEntityType(label, fallbackMasked) {
     let raw = label;
     if (!raw && fallbackMasked) {
-      const stripped = String(fallbackMasked).replace(/^<|>$/g, "");
-      raw = stripped.replace(/_\d+$/, "");
+      const masked = String(fallbackMasked);
+      if (/^<[A-Z_]+(_\d+)?>$/.test(masked)) {
+        raw = masked.replace(/^<|>$/g, "").replace(/_\d+$/, "");
+      }
     }
     if (!raw) return "Unknown";
     return raw


### PR DESCRIPTION
## Summary
- The PII modal's **Type** column was showing the masked replacement itself (e.g. \`25627\`) instead of the entity label (e.g. \`Zip\`) when the backend response didn't carry a matching label for a given masked value.
- Root cause: \`formatEntityType\` fell back to stripping \`<>\` and \`_N\` from the masked value. That was designed for legacy bracket tokens like \`<PERSON_1>\`, but for modern realistic-fake replacements (e.g. \`25627\`) the regex is a no-op and the masked value ends up rendered verbatim as the type.
- Fix: only use the bracket-token fallback when the masked value actually matches \`<LABEL>\` / \`<LABEL_N>\`. Otherwise return \`Unknown\`, so missing labels are at least not misleading.

## Before / After

Before (zipcode row):
| Type | Found | Replaced with |
|---|---|---|
| 25627 | 97204 | 25627 |

After (when label is present):
| Type | Found | Replaced with |
|---|---|---|
| Zip | 97204 | 25627 |

After (when label is missing for any reason):
| Type | Found | Replaced with |
|---|---|---|
| Unknown | 97204 | 25627 |

## Test plan
- [ ] Load the unpacked extension in Chrome
- [ ] Submit a prompt containing a zipcode in ChatGPT and confirm the Type column shows \`Zip\`, not the masked value
- [ ] Submit a prompt with multiple entity types (name, email, zipcode) and confirm each Type is formatted correctly
- [ ] Point the extension at a server that does not return \`detected_entities\` and confirm Type shows \`Unknown\` (not the masked value)

🤖 Generated with [Claude Code](https://claude.com/claude-code)