### PR TITLE
chore: add patch changeset for recent PII fixes

### DIFF
--- a/.changeset/brave-otters-sing.md
+++ b/.changeset/brave-otters-sing.md
@@ -1,0 +1,5 @@
+---
+"kiji-privacy-proxy": patch
+---
+
+Improve PII detection accuracy and masking reliability: updated the base model, corrected BIO labels for multi-word entities, fixed the street name generator, and now show "Unknown" instead of the masked value when an entity label is missing.


### PR DESCRIPTION
## Summary
- Adds a patch changeset covering four recent fixes/updates merged since 0.5.1:
  - Updated base model
  - Corrected BIO labels for multi-word entities
  - Fixed street name generator
  - Show "Unknown" instead of the masked value when an entity label is missing

## Test plan
- [x] Confirm `npx changeset status` picks up the new entry
- [ ] Verify `npm run version` bumps `kiji-privacy-proxy` to the next patch version and updates `chrome-extension/manifest.json`

🤖 Generated with [Claude Code](https://claude.com/claude-code)