### PR TITLE
fix(linux): replace hardcoded app data dir with platform-aware helper

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -12,6 +12,7 @@ Thank you to everyone who has contributed to Kiji Privacy Proxy!
 - **Nils Martorell** ([@nmartorell](https://github.com/nmartorell))
 - **Micaela Kaplan** ([@micaelakaplan](https://github.com/micaelakaplan))
 - **Eddie Mattia** ([@emattia](https://github.com/emattia))
+- **Sebastien G. Claro** ([@s3bc40](https://github.com/s3bc40))
 
 ---
 

--- a/src/backend/config/config.go
+++ b/src/backend/config/config.go
@@ -3,12 +3,12 @@ package config
 import (
 	"errors"
 	"fmt"
-	"os"
 	"path/filepath"
 	"regexp"
 	"strconv"
 	"strings"
 
+	"github.com/hannes/kiji-private/src/backend/paths"
 	"github.com/hannes/kiji-private/src/backend/providers"
 )
 
@@ -185,8 +185,7 @@ func DefaultConfig() *Config {
 	}
 
 	// Application data directory
-	homeDir, _ := os.UserHomeDir()
-	appDataDir := filepath.Join(homeDir, "Library", "Application Support", "Kiji Privacy Proxy")
+	appDataDir := paths.AppDataDir()
 	caPath := filepath.Join(appDataDir, "certs", "ca.crt")
 	keyPath := filepath.Join(appDataDir, "certs", "ca.key")
 	dbPath := filepath.Join(appDataDir, "kiji_privacy_proxy.db")

--- a/src/backend/paths/paths.go
+++ b/src/backend/paths/paths.go
@@ -1,0 +1,18 @@
+package paths
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+)
+
+// AppDataDir returns the platform-appropriate application data directory.
+// macOS: ~/Library/Application Support/Kiji Privacy Proxy
+// Linux/other: ~/.kiji-proxy
+func AppDataDir() string {
+	homeDir, _ := os.UserHomeDir()
+	if runtime.GOOS == "darwin" {
+		return filepath.Join(homeDir, "Library", "Application Support", "Kiji Privacy Proxy")
+	}
+	return filepath.Join(homeDir, ".kiji-proxy")
+}

--- a/src/backend/pii/database.go
+++ b/src/backend/pii/database.go
@@ -11,6 +11,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/hannes/kiji-private/src/backend/paths"
 	detectors "github.com/hannes/kiji-private/src/backend/pii/detectors"
 	_ "modernc.org/sqlite"
 )
@@ -94,8 +95,7 @@ type SQLitePIIMappingDB struct {
 func NewSQLitePIIMappingDB(ctx context.Context, config DatabaseConfig) (*SQLitePIIMappingDB, error) {
 	dbPath := config.Path
 	if dbPath == "" {
-		homeDir, _ := os.UserHomeDir()
-		dbPath = filepath.Join(homeDir, "Library", "Application Support", "Kiji Privacy Proxy", "kiji_privacy_proxy.db")
+		dbPath = filepath.Join(paths.AppDataDir(), "kiji_privacy_proxy.db")
 	}
 
 	// Ensure the directory exists

--- a/src/backend/pii/database_test.go
+++ b/src/backend/pii/database_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/hannes/kiji-private/src/backend/paths"
 	detectors "github.com/hannes/kiji-private/src/backend/pii/detectors"
 )
 
@@ -29,11 +30,7 @@ func newTestDB(t *testing.T) *SQLitePIIMappingDB {
 // --- NewSQLitePIIMappingDB tests ---
 
 func TestNewSQLitePIIMappingDB_DefaultPath(t *testing.T) {
-	homeDir, err := os.UserHomeDir()
-	if err != nil {
-		t.Fatal(err)
-	}
-	expectedPath := filepath.Join(homeDir, "Library", "Application Support", "Kiji Privacy Proxy", "kiji_privacy_proxy.db")
+	expectedPath := filepath.Join(paths.AppDataDir(), "kiji_privacy_proxy.db")
 
 	db, err := NewSQLitePIIMappingDB(context.Background(), DatabaseConfig{})
 	if err != nil {

--- a/src/backend/server/server.go
+++ b/src/backend/server/server.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	"github.com/hannes/kiji-private/src/backend/config"
+	"github.com/hannes/kiji-private/src/backend/paths"
 	"github.com/hannes/kiji-private/src/backend/providers"
 	"github.com/hannes/kiji-private/src/backend/proxy"
 	"golang.org/x/time/rate"
@@ -732,8 +733,7 @@ func (s *Server) handleCACert(w http.ResponseWriter, r *http.Request) {
 	// We need to access the cert manager - for now, read from disk
 	caPath := s.config.Proxy.CAPath
 	if caPath == "" {
-		homeDir, _ := os.UserHomeDir()
-		caPath = filepath.Join(homeDir, "Library", "Application Support", "Kiji Privacy Proxy", "certs", "ca.crt")
+		caPath = filepath.Join(paths.AppDataDir(), "certs", "ca.crt")
 	}
 
 	data, err := os.ReadFile(caPath)


### PR DESCRIPTION
 ## Summary
- Fixes a Linux compatibility bug where the app data directory was hardcoded to a macOS-specific path
- Introduces a new `paths` package with a cross-platform helper for resolving the app data directory
- Updates config, PII database, and server to use the new helper

## Changes
- `src/backend/paths/paths.go`: new package with platform-aware app data dir resolution
- `src/backend/config/config.go`: use `paths` helper instead of hardcoded path
- `src/backend/pii/database.go`: use `paths` helper instead of hardcoded path
- `src/backend/pii/database_test.go`: simplify test setup to use new helper
- `src/backend/server/server.go`: use `paths` helper instead of hardcoded path
- `CONTRIBUTORS.md`: add contributor entry