### PR TITLE
fix: extension PII mask counters and refresh model pipeline artifacts

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -171,19 +171,19 @@ jobs:
           APPLE_API_KEY_ID: ${{ secrets.APPLE_API_KEY_ID }}
           APPLE_API_ISSUER: ${{ secrets.APPLE_API_ISSUER }}
 
-      - name: Rename DMG with Version
+      - name: Normalize macOS Artifact Names
         run: |
           cd src/frontend/release
-          for dmg in *.dmg; do
-            if [ -f "$dmg" ]; then
-              # Replace spaces with hyphens for cleaner filename
-              # Example: "Kiji Privacy Proxy-0.2.0.dmg" -> "Kiji-Privacy-Proxy-0.2.0.dmg"
-              NEW_NAME=$(echo "$dmg" | tr ' ' '-')
-              if [ "$dmg" != "$NEW_NAME" ]; then
-                mv "$dmg" "$NEW_NAME"
-                echo "Renamed: $dmg -> $NEW_NAME"
+          for artifact in *.dmg *-mac.zip; do
+            if [ -f "$artifact" ]; then
+              # Match the artifact names generated in latest-mac.yml.
+              # Example: "Kiji Privacy Proxy-0.2.0-arm64-mac.zip" -> "Kiji-Privacy-Proxy-0.2.0-arm64-mac.zip"
+              new_name=$(echo "$artifact" | tr ' ' '-')
+              if [ "$artifact" != "$new_name" ]; then
+                mv "$artifact" "$new_name"
+                echo "Renamed: $artifact -> $new_name"
               else
-                echo "Already clean: $dmg"
+                echo "Already clean: $artifact"
               fi
             fi
           done

--- a/chrome-extension/PRIVACY_POLICY.md
+++ b/chrome-extension/PRIVACY_POLICY.md
@@ -15,7 +15,7 @@ The Kiji Privacy Proxy Extension checks text you type into AI chat services (suc
 ### What data is stored locally
 
 - **Settings:** your backend server URL and the list of monitored domains (stored in `chrome.storage.sync`).
-- **Session statistics:** the number of messages checked and the number containing PII (stored in `chrome.storage.local`). These counters reset when the extension is reinstalled.
+- **Session statistics:** the number of messages checked and the number of PII entities masked after you choose the masked version (stored in `chrome.storage.local`). These counters reset when the extension is reinstalled.
 
 ### What data is transmitted
 
@@ -55,4 +55,3 @@ Updates to this policy will be posted in the extension's GitHub repository. The 
 ## Contact
 
 For questions about this privacy policy or the extension's data practices, please open an issue at: https://github.com/dataiku/kiji-proxy/issues
-

--- a/chrome-extension/background.js
+++ b/chrome-extension/background.js
@@ -153,7 +153,12 @@ function scheduleNextCheck() {
 // --- Lifecycle ---
 
 chrome.runtime.onInstalled.addListener(() => {
-  chrome.storage.local.set({ checksTotal: 0, piiFound: 0, connected: false });
+  chrome.storage.local.set({
+    checksTotal: 0,
+    piiMasked: 0,
+    connected: false,
+  });
+  chrome.storage.local.remove("piiFound");
   loadSettingsAndCheck();
   loadDomainsAndRegister();
 });
@@ -213,12 +218,8 @@ async function handlePIICheck(text) {
     return { success: false, error, url };
   }
 
-  chrome.storage.local.get({ checksTotal: 0, piiFound: 0 }, (result) => {
-    const updates = { checksTotal: result.checksTotal + 1 };
-    if (data.pii_found) {
-      updates.piiFound = result.piiFound + 1;
-    }
-    chrome.storage.local.set(updates);
+  chrome.storage.local.get({ checksTotal: 0 }, (result) => {
+    chrome.storage.local.set({ checksTotal: result.checksTotal + 1 });
   });
 
   return { success: true, data };
@@ -230,24 +231,23 @@ chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
     return true; // keep channel open for async sendResponse
   }
 
-  if (message.type === "pii-check") {
-    chrome.storage.local.get({ checksTotal: 0, piiFound: 0 }, (result) => {
-      const updates = { checksTotal: result.checksTotal + 1 };
-      if (message.found) {
-        updates.piiFound = result.piiFound + 1;
-      }
-      chrome.storage.local.set(updates);
+  if (message.type === "pii-masked") {
+    const count = Number.isFinite(message.count)
+      ? Math.max(0, Math.floor(message.count))
+      : 0;
+    chrome.storage.local.get({ piiMasked: 0 }, (result) => {
+      chrome.storage.local.set({ piiMasked: result.piiMasked + count });
     });
   }
 
   if (message.type === "get-status") {
     chrome.storage.local.get(
-      { connected: false, checksTotal: 0, piiFound: 0 },
+      { connected: false, checksTotal: 0, piiMasked: 0 },
       (result) => {
         sendResponse({
           connected: result.connected,
           checksTotal: result.checksTotal,
-          piiFound: result.piiFound,
+          piiMasked: result.piiMasked,
           backendUrl: backendUrl,
         });
       }
@@ -258,12 +258,12 @@ chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
   if (message.type === "refresh-status") {
     checkHealth().then(() => {
       chrome.storage.local.get(
-        { connected: false, checksTotal: 0, piiFound: 0 },
+        { connected: false, checksTotal: 0, piiMasked: 0 },
         (result) => {
           sendResponse({
             connected: result.connected,
             checksTotal: result.checksTotal,
-            piiFound: result.piiFound,
+            piiMasked: result.piiMasked,
             backendUrl: backendUrl,
           });
         }

--- a/chrome-extension/content.js
+++ b/chrome-extension/content.js
@@ -289,6 +289,16 @@
   let lastCheckError = null;
   let contextInvalidated = false;
 
+  function countMaskedEntities(result) {
+    if (Array.isArray(result?.detected_entities)) {
+      return result.detected_entities.length;
+    }
+    if (result?.entities && typeof result.entities === "object") {
+      return Object.keys(result.entities).length;
+    }
+    return result?.pii_found ? 1 : 0;
+  }
+
   function isExtensionAlive() {
     try {
       return !!(chrome.runtime && chrome.runtime.id);
@@ -403,18 +413,6 @@
         return;
       }
 
-      // Notify background service worker of the check result
-      if (isExtensionAlive()) {
-        try {
-          chrome.runtime.sendMessage({
-            type: "pii-check",
-            found: result.pii_found,
-          });
-        } catch (e) {
-          // Background may not be available
-        }
-      }
-
       if (result.pii_found) {
         console.log("Kiji Privacy Proxy Extension: PII detected");
         showPIIModal(result, text, (action, maskedText) => {
@@ -425,6 +423,16 @@
             case "use-masked":
               setInputText(maskedText);
               maskedTextPending = maskedText;
+              if (isExtensionAlive()) {
+                try {
+                  chrome.runtime.sendMessage({
+                    type: "pii-masked",
+                    count: countMaskedEntities(result),
+                  });
+                } catch (e) {
+                  // Background may not be available
+                }
+              }
               // Don't auto-submit, let user review the masked text first
               break;
             case "send-anyway":

--- a/chrome-extension/popup.html
+++ b/chrome-extension/popup.html
@@ -40,7 +40,7 @@
           <span class="stat-label">Messages checked</span>
         </div>
         <div class="stat stat-accent">
-          <span class="stat-value" id="pii-found">0</span>
+          <span class="stat-value" id="pii-masked">0</span>
           <span class="stat-label">PII masked</span>
         </div>
       </section>

--- a/chrome-extension/popup.js
+++ b/chrome-extension/popup.js
@@ -46,10 +46,11 @@ function setStatus({ connected, host, backendUrl }) {
   }
 }
 
-function setStats({ checksTotal = 0, piiFound = 0 }) {
+function setStats({ checksTotal = 0, piiMasked = 0 }) {
   document.getElementById("checks-total").textContent =
     checksTotal.toLocaleString();
-  document.getElementById("pii-found").textContent = piiFound.toLocaleString();
+  document.getElementById("pii-masked").textContent =
+    piiMasked.toLocaleString();
 }
 
 let lastBackendUrl = null;
@@ -66,7 +67,7 @@ function applyState(state) {
   });
   setStats({
     checksTotal: state.checksTotal ?? 0,
-    piiFound: state.piiFound ?? 0,
+    piiMasked: state.piiMasked ?? 0,
   });
 }
 
@@ -90,9 +91,9 @@ function subscribeToLiveUpdates() {
   chrome.storage.onChanged.addListener((changes, area) => {
     if (area !== "local") return;
 
-    if (changes.connected || changes.checksTotal || changes.piiFound) {
+    if (changes.connected || changes.checksTotal || changes.piiMasked) {
       chrome.storage.local.get(
-        { connected: false, checksTotal: 0, piiFound: 0 },
+        { connected: false, checksTotal: 0, piiMasked: 0 },
         (result) => {
           applyState({ ...result, backendUrl: lastBackendUrl });
         }

--- a/docs/06-chrome-extension.md
+++ b/docs/06-chrome-extension.md
@@ -60,7 +60,7 @@ chrome-extension/
 1. `background.js` dynamically registers `content.js` on user-configured domains
 2. `content.js` intercepts form submission, sends text to the backend `/api/pii/check` endpoint
 3. If PII is found, a modal is shown with mask/cancel/send options
-4. `content.js` reports check results to `background.js` for stats tracking
+4. `background.js` records each completed check, and `content.js` reports how many entities were masked when the masked version is used
 5. `background.js` runs periodic health checks and updates the badge icon
 
 ## Configuration
@@ -176,7 +176,7 @@ Required for any extension that handles user data. Host it at a public URL (GitH
 
 - **What data is collected:** Text from chat input fields on configured domains, only at the moment of submission
 - **Where data is sent:** To a user-configured backend server (default: localhost). No data is sent to third parties.
-- **What is stored:** The extension stores settings (backend URL, domain list) and session statistics (check count, PII detection count) locally. No message content is stored.
+- **What is stored:** The extension stores settings (backend URL, domain list) and session statistics (check count, masked PII entity count) locally. No message content is stored.
 - **Data retention:** Session statistics are cleared on extension reinstall. No message content is retained.
 - **User control:** Users choose which domains are intercepted and where data is sent. All PII checking can be bypassed via "Send Anyway."
 

--- a/model/dataset/tokenization.py
+++ b/model/dataset/tokenization.py
@@ -91,7 +91,9 @@ class TokenizationProcessor:
         # Sort by start position (reverse order for replacement)
         return self._drop_overlapping_positions(privacy_mask_with_positions)
 
-    def _split_words_with_spans(self, text: str) -> tuple[list[str], list[tuple[int, int]]]:
+    def _split_words_with_spans(
+        self, text: str
+    ) -> tuple[list[str], list[tuple[int, int]]]:
         """Split text like ``str.split`` while keeping original character spans."""
         words = []
         spans = []
@@ -159,7 +161,11 @@ class TokenizationProcessor:
         privacy_mask_with_positions: list[dict[str, Any]] | None,
     ) -> bool:
         """Check whether a token span overlaps an entity span with the same label."""
-        if token_start < 0 or token_end <= token_start or not privacy_mask_with_positions:
+        if (
+            token_start < 0
+            or token_end <= token_start
+            or not privacy_mask_with_positions
+        ):
             return False
 
         for item in privacy_mask_with_positions:

--- a/model/dataset/tokenization.py
+++ b/model/dataset/tokenization.py
@@ -74,8 +74,6 @@ class TokenizationProcessor:
                 # Validate that the offset matches the expected value
                 actual = text[entry["start"] : entry["end"]]
                 if actual != entry["value"]:
-                    import logging
-
                     logging.getLogger(__name__).debug(
                         "Offset mismatch: expected '%s' but found '%s' at [%d:%d]",
                         entry["value"],
@@ -92,6 +90,15 @@ class TokenizationProcessor:
 
         # Sort by start position (reverse order for replacement)
         return self._drop_overlapping_positions(privacy_mask_with_positions)
+
+    def _split_words_with_spans(self, text: str) -> tuple[list[str], list[tuple[int, int]]]:
+        """Split text like ``str.split`` while keeping original character spans."""
+        words = []
+        spans = []
+        for match in re.finditer(r"\S+", text):
+            words.append(match.group(0))
+            spans.append((match.start(), match.end()))
+        return words, spans
 
     def _create_word_labels(
         self, text: str, privacy_mask_with_positions: list[dict[str, Any]]
@@ -144,45 +151,47 @@ class TokenizationProcessor:
         punctuation_chars = set(",.;:!?)]}['\"-–—()[]{}")
         return all(c in punctuation_chars for c in stripped)
 
-    def _is_punctuation_in_entity(
+    def _token_overlaps_entity(
         self,
-        punct_text: str,
-        word_idx: int,
-        words_original: list[str] | None,
+        token_start: int,
+        token_end: int,
+        entity_label: str,
         privacy_mask_with_positions: list[dict[str, Any]] | None,
     ) -> bool:
-        """Check if punctuation is part of an entity value.
-
-        Uses character positions to determine whether the punctuation token
-        falls within an entity span, avoiding false positives from string
-        containment (e.g. the trailing comma in ``"1988,"`` should not match
-        the internal comma in ``"April 12, 1988"``).
-        """
-        if (
-            not words_original
-            or not privacy_mask_with_positions
-            or word_idx >= len(words_original)
-        ):
+        """Check whether a token span overlaps an entity span with the same label."""
+        if token_start < 0 or token_end <= token_start or not privacy_mask_with_positions:
             return False
 
-        # Reconstruct the character offset of this word by summing lengths
-        # of preceding words plus whitespace gaps.  text.split() tokens are
-        # separated by single spaces in the offset arithmetic.
-        char_pos = 0
-        for i in range(word_idx):
-            char_pos += len(words_original[i]) + 1  # +1 for the space
-
-        original_word = words_original[word_idx]
-        # The punctuation is at the trailing end of the word
-        punct_char_pos = char_pos + len(original_word) - len(punct_text)
-
         for item in privacy_mask_with_positions:
+            if item.get("label") != entity_label:
+                continue
             entity_start = item.get("start", 0)
             entity_end = item.get("end", 0)
-            # Punctuation is inside entity if its position falls within the span
-            if entity_start <= punct_char_pos < entity_end:
+            if token_start < entity_end and entity_start < token_end:
                 return True
         return False
+
+    def _absolute_token_offsets(
+        self,
+        word_ids: list[int | None],
+        token_offsets: list[tuple[int, int]] | None,
+        word_spans: list[tuple[int, int]],
+    ) -> list[tuple[int, int]]:
+        """Convert split-word tokenizer offsets back to original text offsets."""
+        if token_offsets is None:
+            return [(-1, -1)] * len(word_ids)
+
+        absolute_offsets = []
+        for word_idx, token_offset in zip(word_ids, token_offsets, strict=True):
+            if word_idx is None or word_idx >= len(word_spans):
+                absolute_offsets.append((-1, -1))
+                continue
+
+            word_start, _word_end = word_spans[word_idx]
+            token_start, token_end = token_offset
+            absolute_offsets.append((word_start + token_start, word_start + token_end))
+
+        return absolute_offsets
 
     def _get_label_id(self, bio_label: str) -> int:
         """Get the label ID for a BIO-prefixed label (e.g. ``B-EMAIL``, ``I-SSN``, ``O``)."""
@@ -195,7 +204,7 @@ class TokenizationProcessor:
         word_labels: list[str],
         word_ids: list[int | None],
         token_texts: list[str] | None = None,
-        words_original: list[str] | None = None,
+        token_offsets: list[tuple[int, int]] | None = None,
         privacy_mask_with_positions: list[dict[str, Any]] | None = None,
     ) -> list[int]:
         """Align word-level BIO labels with token IDs.
@@ -224,11 +233,13 @@ class TokenizationProcessor:
                 base = (
                     bio_label[2:] if bio_label.startswith(("B-", "I-")) else bio_label
                 )
-                if base != "O" and not self._is_punctuation_in_entity(
-                    token_text.strip(),
-                    word_idx,
-                    words_original,
-                    privacy_mask_with_positions,
+                token_start, token_end = (
+                    token_offsets[idx]
+                    if token_offsets and idx < len(token_offsets)
+                    else (-1, -1)
+                )
+                if base != "O" and not self._token_overlaps_entity(
+                    token_start, token_end, base, privacy_mask_with_positions
                 ):
                     bio_label = "O"
 
@@ -258,7 +269,7 @@ class TokenizationProcessor:
         word_labels = self._create_word_labels(text, privacy_mask_with_positions)
 
         # Tokenize the original text
-        words_original = text.split()
+        words_original, word_spans = self._split_words_with_spans(text)
         tokenized = self.tokenizer(
             words_original,
             truncation=True,
@@ -272,6 +283,11 @@ class TokenizationProcessor:
             word_ids = tokenized.word_ids(batch_index=0)
         except (TypeError, AttributeError):
             word_ids = tokenized.word_ids()
+
+        token_offsets = tokenized.get("offset_mapping")
+        absolute_token_offsets = self._absolute_token_offsets(
+            word_ids, token_offsets, word_spans
+        )
 
         # Get token texts to check for punctuation-only tokens
         # Use raw token strings for better punctuation detection
@@ -318,7 +334,7 @@ class TokenizationProcessor:
             word_labels,
             word_ids,
             token_texts,
-            words_original,
+            absolute_token_offsets,
             privacy_mask_with_positions,
         )
 

--- a/model/dataset/tokenization.py
+++ b/model/dataset/tokenization.py
@@ -1,7 +1,6 @@
 """Tokenization utilities for training samples."""
 
 import logging
-import re
 from typing import Any
 
 from transformers import AutoTokenizer
@@ -91,60 +90,6 @@ class TokenizationProcessor:
         # Sort by start position (reverse order for replacement)
         return self._drop_overlapping_positions(privacy_mask_with_positions)
 
-    def _split_words_with_spans(
-        self, text: str
-    ) -> tuple[list[str], list[tuple[int, int]]]:
-        """Split text like ``str.split`` while keeping original character spans."""
-        words = []
-        spans = []
-        for match in re.finditer(r"\S+", text):
-            words.append(match.group(0))
-            spans.append((match.start(), match.end()))
-        return words, spans
-
-    def _create_word_labels(
-        self, text: str, privacy_mask_with_positions: list[dict[str, Any]]
-    ) -> list[str]:
-        """Create word-level BIO labels from privacy mask positions.
-
-        Each word gets a BIO-prefixed label: ``B-LABEL`` for the first word
-        of an entity span and ``I-LABEL`` for subsequent words.  Words outside
-        any entity span receive ``O``.
-        """
-        # Replace sensitive text with BIO-prefixed label placeholders.
-        # privacy_mask_with_positions is sorted by start descending, so
-        # replacing from the end preserves earlier offsets.
-        text_with_labels = text
-        for item in privacy_mask_with_positions:
-            label = item["label"]
-            start = item["start"]
-            end = item["end"]
-            value = item["value"]
-
-            word_count = len(value.split())
-            bio_labels = [f"B-{label}"] + [f"I-{label}"] * (word_count - 1)
-            replacement = " ".join(bio_labels)
-            text_with_labels = (
-                text_with_labels[:start] + replacement + text_with_labels[end:]
-            )
-
-        # Split into words and parse BIO labels
-        words = text_with_labels.split()
-        word_labels = []
-        for word in words:
-            match = re.search(r"(\w[\w-]*)", word)
-            if match:
-                token = match.group(1)
-                # Check for BIO-prefixed PII labels (e.g. B-EMAIL, I-FIRSTNAME)
-                if token.startswith(("B-", "I-")):
-                    word_labels.append(token)
-                else:
-                    word_labels.append("O")
-            else:
-                word_labels.append("O")
-
-        return word_labels
-
     def _is_punctuation_only(self, token_text: str) -> bool:
         """Check if a token contains only punctuation characters."""
         stripped = token_text.strip()
@@ -177,27 +122,28 @@ class TokenizationProcessor:
                 return True
         return False
 
-    def _absolute_token_offsets(
+    def _best_entity_for_token(
         self,
-        word_ids: list[int | None],
-        token_offsets: list[tuple[int, int]] | None,
-        word_spans: list[tuple[int, int]],
-    ) -> list[tuple[int, int]]:
-        """Convert split-word tokenizer offsets back to original text offsets."""
-        if token_offsets is None:
-            return [(-1, -1)] * len(word_ids)
+        token_start: int,
+        token_end: int,
+        privacy_mask_with_positions: list[dict[str, Any]],
+    ) -> dict[str, Any] | None:
+        """Return the entity span with the largest overlap for a token."""
+        best_entity = None
+        best_overlap = 0
 
-        absolute_offsets = []
-        for word_idx, token_offset in zip(word_ids, token_offsets, strict=True):
-            if word_idx is None or word_idx >= len(word_spans):
-                absolute_offsets.append((-1, -1))
-                continue
+        for item in privacy_mask_with_positions:
+            entity_start = item.get("start", 0)
+            entity_end = item.get("end", 0)
+            overlap = max(
+                0,
+                min(token_end, entity_end) - max(token_start, entity_start),
+            )
+            if overlap > best_overlap:
+                best_overlap = overlap
+                best_entity = item
 
-            word_start, _word_end = word_spans[word_idx]
-            token_start, token_end = token_offset
-            absolute_offsets.append((word_start + token_start, word_start + token_end))
-
-        return absolute_offsets
+        return best_entity
 
     def _get_label_id(self, bio_label: str) -> int:
         """Get the label ID for a BIO-prefixed label (e.g. ``B-EMAIL``, ``I-SSN``, ``O``)."""
@@ -205,60 +151,62 @@ class TokenizationProcessor:
             return 0
         return self.label2id.get(bio_label, 0)
 
-    def _align_labels_with_tokens(
+    def _align_labels_with_offsets(
         self,
-        word_labels: list[str],
-        word_ids: list[int | None],
-        token_texts: list[str] | None = None,
-        token_offsets: list[tuple[int, int]] | None = None,
-        privacy_mask_with_positions: list[dict[str, Any]] | None = None,
+        token_offsets: list[tuple[int, int]] | None,
+        token_texts: list[str] | None,
+        privacy_mask_with_positions: list[dict[str, Any]],
     ) -> list[int]:
-        """Align word-level BIO labels with token IDs.
+        """Align BIO labels directly from character spans to token offsets."""
+        if token_offsets is None:
+            return []
 
-        ``word_labels`` already carry the correct BIO prefix (``B-LABEL``,
-        ``I-LABEL``, or ``O``).  Sub-word tokens that continue the same
-        word receive the ``I-`` variant of their word's label.
-        """
+        sorted_positions = sorted(
+            privacy_mask_with_positions,
+            key=lambda item: (item["start"], item["end"], item["label"]),
+        )
         label_ids = []
-        prev_word_idx = None
+        prev_entity_key = None
 
-        for idx, word_idx in enumerate(word_ids):
-            # Handle special tokens and out-of-bounds
-            if word_idx is None or word_idx >= len(word_labels):
+        for idx, (token_start, token_end) in enumerate(token_offsets):
+            if token_end <= token_start:
                 label_ids.append(-100)
+                prev_entity_key = None
                 continue
 
-            bio_label = word_labels[word_idx]
             token_text = (
                 token_texts[idx] if token_texts and idx < len(token_texts) else ""
             )
-            is_punct = self._is_punctuation_only(token_text)
+            entity = self._best_entity_for_token(
+                token_start,
+                token_end,
+                sorted_positions,
+            )
+            if entity is None:
+                label_ids.append(0)
+                prev_entity_key = None
+                continue
 
-            # Determine effective label for this token
-            if is_punct:
-                base = (
-                    bio_label[2:] if bio_label.startswith(("B-", "I-")) else bio_label
-                )
-                token_start, token_end = (
-                    token_offsets[idx]
-                    if token_offsets and idx < len(token_offsets)
-                    else (-1, -1)
-                )
-                if base != "O" and not self._token_overlaps_entity(
-                    token_start, token_end, base, privacy_mask_with_positions
-                ):
-                    bio_label = "O"
+            label = entity["label"]
+            entity_key = (entity["start"], entity["end"], label)
+            prefix = "I" if entity_key == prev_entity_key else "B"
 
-            # Sub-word continuation: second+ token of the same word gets I-
-            if word_idx == prev_word_idx and bio_label.startswith("B-"):
-                bio_label = "I-" + bio_label[2:]
+            # Keep punctuation that is inside the entity span (email dots, phone
+            # separators), but leave standalone punctuation outside spans as O.
+            if self._is_punctuation_only(
+                token_text
+            ) and not self._token_overlaps_entity(
+                token_start,
+                token_end,
+                label,
+                sorted_positions,
+            ):
+                label_ids.append(0)
+                prev_entity_key = None
+                continue
 
-            label_ids.append(self._get_label_id(bio_label))
-            prev_word_idx = word_idx
-
-        # Truncate to max_length if needed
-        if len(label_ids) > 512:
-            label_ids = label_ids[:511] + [-100]
+            label_ids.append(self._get_label_id(f"{prefix}-{label}"))
+            prev_entity_key = entity_key
 
         return label_ids
 
@@ -271,29 +219,13 @@ class TokenizationProcessor:
             text, privacy_mask
         )
 
-        # Create word-level labels
-        word_labels = self._create_word_labels(text, privacy_mask_with_positions)
-
-        # Tokenize the original text
-        words_original, word_spans = self._split_words_with_spans(text)
         tokenized = self.tokenizer(
-            words_original,
+            text,
             truncation=True,
-            is_split_into_words=True,
             max_length=512,
             return_offsets_mapping=True,
         )
-
-        # Get word IDs for alignment
-        try:
-            word_ids = tokenized.word_ids(batch_index=0)
-        except (TypeError, AttributeError):
-            word_ids = tokenized.word_ids()
-
         token_offsets = tokenized.get("offset_mapping")
-        absolute_token_offsets = self._absolute_token_offsets(
-            word_ids, token_offsets, word_spans
-        )
 
         # Get token texts to check for punctuation-only tokens
         # Use raw token strings for better punctuation detection
@@ -335,12 +267,12 @@ class TokenizationProcessor:
         except (TypeError, KeyError, IndexError, AttributeError):
             token_texts = None
 
-        # Align labels with tokens
-        label_ids = self._align_labels_with_tokens(
-            word_labels,
-            word_ids,
+        # Align labels directly from annotation character spans. This handles
+        # compact formats such as XML/JSON/email addresses where entities are
+        # embedded inside a whitespace-delimited "word".
+        label_ids = self._align_labels_with_offsets(
+            token_offsets,
             token_texts,
-            absolute_token_offsets,
             privacy_mask_with_positions,
         )
 

--- a/model/dataset/tokenization.py
+++ b/model/dataset/tokenization.py
@@ -1,5 +1,6 @@
 """Tokenization utilities for training samples."""
 
+import logging
 import re
 from typing import Any
 
@@ -18,6 +19,38 @@ class TokenizationProcessor:
         self.tokenizer = tokenizer
         self.label2id = label2id
         self.id2label = id2label
+
+    def _drop_overlapping_positions(
+        self, positions: list[dict[str, Any]]
+    ) -> list[dict[str, Any]]:
+        """Drop overlapping spans before string replacement.
+
+        A single token can only have one BIO label. If the source annotations contain
+        nested or overlapping spans, keep the longest span and drop the shorter one
+        so label replacement cannot corrupt neighboring text.
+        """
+        kept: list[dict[str, Any]] = []
+        dropped = 0
+
+        for item in sorted(
+            positions,
+            key=lambda x: (-(x["end"] - x["start"]), x["start"], x["label"]),
+        ):
+            overlaps_kept = any(
+                item["start"] < kept_item["end"] and kept_item["start"] < item["end"]
+                for kept_item in kept
+            )
+            if overlaps_kept:
+                dropped += 1
+                continue
+            kept.append(item)
+
+        if dropped:
+            logging.getLogger(__name__).debug(
+                "Dropped %d overlapping privacy-mask span(s)", dropped
+            )
+
+        return sorted(kept, key=lambda x: x["start"], reverse=True)
 
     def _find_privacy_mask_positions(
         self, text: str, privacy_mask: list[dict[str, str]]
@@ -58,9 +91,7 @@ class TokenizationProcessor:
                 )
 
         # Sort by start position (reverse order for replacement)
-        return sorted(
-            privacy_mask_with_positions, key=lambda x: x["start"], reverse=True
-        )
+        return self._drop_overlapping_positions(privacy_mask_with_positions)
 
     def _create_word_labels(
         self, text: str, privacy_mask_with_positions: list[dict[str, Any]]

--- a/model/flows/training_config.toml
+++ b/model/flows/training_config.toml
@@ -13,9 +13,11 @@ torch_compile = true       # torch.compile optimization (10-20% speedup on H100)
 
 warmup_steps = 500        # Gradual LR ramp-up to stabilize early training
 weight_decay = 0.01       # L2 regularization strength
+auxiliary_ce_loss_weight = 0.2  # Weighted token CE added to CRF loss for rare labels
 
 # Early stopping settings
-max_eval_samples = 2000         # Cap eval set size for faster evaluation
+max_eval_samples = 0            # Cap eval set size for faster evaluation (0 = no cap)
+balanced_validation_split = true
 early_stopping_enabled = true
 early_stopping_patience = 3   # Number of epochs with no improvement before stopping
 early_stopping_threshold = 0.005  # Minimum improvement (0.5%) to qualify as improvement

--- a/model/flows/training_config.toml
+++ b/model/flows/training_config.toml
@@ -9,7 +9,7 @@ num_epochs = 30
 batch_size = 128
 learning_rate = 2e-5
 bf16 = true                # Mixed precision for Ampere+ GPUs (H100, A100, etc.)
-torch_compile = true       # torch.compile optimization (10-20% speedup on H100)
+torch_compile = false      # Keep torch.compile disabled during training
 
 warmup_steps = 500        # Gradual LR ramp-up to stabilize early training
 weight_decay = 0.01       # L2 regularization strength

--- a/model/flows/training_pipeline.py
+++ b/model/flows/training_pipeline.py
@@ -154,9 +154,7 @@ class PIITrainingPipeline(FlowSpec):
             balanced_validation_split=training_cfg.get(
                 "balanced_validation_split", True
             ),
-            auxiliary_ce_loss_weight=training_cfg.get(
-                "auxiliary_ce_loss_weight", 0.2
-            ),
+            auxiliary_ce_loss_weight=training_cfg.get("auxiliary_ce_loss_weight", 0.2),
             audit_allowlist=cfg.get("data", {}).get("audit_allowlist", ""),
         )
         self.skip_export = cfg.get("pipeline", {}).get("skip_export", False)
@@ -368,6 +366,13 @@ class PIITrainingPipeline(FlowSpec):
 
         from src.quantitize import export_to_onnx, load_model, quantize_model
 
+        if self.skip_quantization:
+            print("Skipping quantization by configuration")
+            self.quantized_model_path = None
+            self.quantized_model = None
+            self.next(self.sign_model)
+            return
+
         try:
             model_path = current.model.loaded["trained_model"]
             model, label_mappings, tokenizer = load_model(model_path)
@@ -405,6 +410,7 @@ class PIITrainingPipeline(FlowSpec):
             print(f"Quantization failed: {e}")
             self.quantized_model_path = None
             self.quantized_model = None
+            raise
 
         self.next(self.sign_model)
 

--- a/model/flows/training_pipeline.py
+++ b/model/flows/training_pipeline.py
@@ -151,6 +151,12 @@ class PIITrainingPipeline(FlowSpec):
             bf16=training_cfg.get("bf16", False),
             torch_compile=training_cfg.get("torch_compile", False),
             max_eval_samples=training_cfg.get("max_eval_samples", 0),
+            balanced_validation_split=training_cfg.get(
+                "balanced_validation_split", True
+            ),
+            auxiliary_ce_loss_weight=training_cfg.get(
+                "auxiliary_ce_loss_weight", 0.2
+            ),
             audit_allowlist=cfg.get("data", {}).get("audit_allowlist", ""),
         )
         self.skip_export = cfg.get("pipeline", {}).get("skip_export", False)

--- a/model/flows/training_pipeline.py
+++ b/model/flows/training_pipeline.py
@@ -409,6 +409,7 @@ class PIITrainingPipeline(FlowSpec):
         self.next(self.sign_model)
 
     # @pypi(packages=SIGNING_PACKAGES, python="3.13")
+    @checkpoint
     @model(load=["trained_model"])  # Only require trained_model; quantized is optional
     @step
     def sign_model(self):

--- a/model/quantized/config.json
+++ b/model/quantized/config.json
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:08da16ed5b6ce46b77c019c6422d2114b205bce9359b18897b530df7466d812a
+size 823

--- a/model/quantized/crf_transitions.json
+++ b/model/quantized/crf_transitions.json
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:da480694d3882c8562bc4959ff1fc6869c79cc7e6e1a4c8825776e8688788812
-size 63902
+oid sha256:62158cc212a93ef9f242d5d9f83441d83faffe2b7beae3441c1b291faf3d47d0
+size 63857

--- a/model/quantized/model_quantized.onnx
+++ b/model/quantized/model_quantized.onnx
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:1baf9cdfc99a45ad6e665fef65f1a10ce52b35fa4cb605eba36a9a4c6d9566ef
+oid sha256:323a41cfe2a5807d037282b5e0b6bcb2143242c61457030d074cd3c552ff0bdc
 size 244317403

--- a/model/src/callbacks.py
+++ b/model/src/callbacks.py
@@ -65,6 +65,8 @@ class CleanMetricsCallback(TrainerCallback):
         entity_metrics = {}
         for key, val in metrics.items():
             if key.startswith("eval_pii_f1_") and key not in (
+                "eval_pii_f1_macro",
+                "eval_pii_f1_weighted",
                 "eval_pii_f1_micro_avg",
                 "eval_pii_f1_macro_avg",
                 "eval_pii_f1_weighted_avg",

--- a/model/src/checkpoint_utils.py
+++ b/model/src/checkpoint_utils.py
@@ -1,0 +1,66 @@
+"""Utilities for loading trained model checkpoints safely."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any
+
+import torch
+
+STATE_DICT_PREFIXES = ("model.", "_orig_mod.", "module.")
+CRITICAL_WEIGHT_PREFIXES = ("encoder.", "pii_classifier.", "crf.")
+
+
+def normalize_state_dict_keys(
+    state_dict: Mapping[str, Any],
+) -> dict[str, torch.Tensor]:
+    """Strip common wrapper prefixes from a model state dict."""
+    normalized = dict(state_dict)
+
+    changed = True
+    while changed:
+        changed = False
+        for prefix in STATE_DICT_PREFIXES:
+            prefixed = {
+                key[len(prefix) :]: value
+                for key, value in normalized.items()
+                if key.startswith(prefix)
+            }
+            if prefixed and len(prefixed) >= len(normalized) / 2:
+                normalized = prefixed
+                changed = True
+                break
+
+    return normalized
+
+
+def load_compatible_state_dict(
+    model: torch.nn.Module,
+    state_dict: Mapping[str, Any],
+    *,
+    source: str,
+) -> Any:
+    """Load a checkpoint and fail if critical PII model weights are missing."""
+    normalized = normalize_state_dict_keys(state_dict)
+    incompatible = model.load_state_dict(normalized, strict=False)
+
+    critical_missing = [
+        key
+        for key in incompatible.missing_keys
+        if key.startswith(CRITICAL_WEIGHT_PREFIXES)
+    ]
+    if critical_missing:
+        missing_preview = ", ".join(critical_missing[:20])
+        if len(critical_missing) > 20:
+            missing_preview += ", ..."
+        unexpected_preview = ", ".join(incompatible.unexpected_keys[:20])
+        if len(incompatible.unexpected_keys) > 20:
+            unexpected_preview += ", ..."
+        detail = f" Missing critical weights: {missing_preview}."
+        if unexpected_preview:
+            detail += f" Unexpected checkpoint keys include: {unexpected_preview}."
+        raise RuntimeError(
+            f"Checkpoint {source} is incompatible with PIIDetectionModel.{detail}"
+        )
+
+    return incompatible

--- a/model/src/compare_models.py
+++ b/model/src/compare_models.py
@@ -38,6 +38,11 @@ try:
 except ImportError:
     from .model import PIIDetectionModel
 
+try:
+    from model.src.checkpoint_utils import load_compatible_state_dict
+except ImportError:
+    from .checkpoint_utils import load_compatible_state_dict
+
 # Define command-line flags
 FLAGS = flags.FLAGS
 
@@ -147,15 +152,16 @@ def load_pytorch_model(
             model_weights_path, map_location="cpu", weights_only=False
         )
 
-    # Handle 'model.' prefix
-    if any(k.startswith("model.") for k in state_dict.keys()):
-        state_dict = {
-            k.replace("model.", ""): v
-            for k, v in state_dict.items()
-            if k.startswith("model.")
-        }
-
-    model.load_state_dict(state_dict, strict=False)
+    load_info = load_compatible_state_dict(
+        model,
+        state_dict,
+        source=str(model_weights_path),
+    )
+    if load_info.unexpected_keys:
+        logging.warning(
+            "  Ignoring unexpected checkpoint keys: %s",
+            load_info.unexpected_keys[:20],
+        )
     model.eval()
 
     logging.info(f"  Loaded PyTorch model with {num_pii_labels} PII labels")

--- a/model/src/compare_models.py
+++ b/model/src/compare_models.py
@@ -105,12 +105,21 @@ def load_pytorch_model(
 
     # Load model config
     config_path = model_path / "config.json"
+    model_type_defaults = {
+        "bert": "bert-base-cased",
+        "distilbert": "distilbert-base-cased",
+        "roberta": "roberta-base",
+        "deberta-v2": "microsoft/deberta-v3-base",
+    }
     if config_path.exists():
         with config_path.open() as f:
             model_config = json.load(f)
-        base_model_name = model_config.get("_name_or_path", "microsoft/deberta-v3-base")
-        if base_model_name == "distilbert":
-            base_model_name = "distilbert-base-cased"
+        base_model_name = model_config.get("_name_or_path", "")
+        if not base_model_name or base_model_name in model_type_defaults:
+            model_type = model_config.get("model_type", "distilbert")
+            base_model_name = model_type_defaults.get(
+                model_type, "microsoft/deberta-v3-base"
+            )
     else:
         base_model_name = "microsoft/deberta-v3-base"
 

--- a/model/src/config.py
+++ b/model/src/config.py
@@ -48,10 +48,14 @@ class TrainingConfig:
     use_wandb: bool = False
     use_custom_loss: bool = True
     class_weights: dict[int, float] = field(default_factory=dict)
+    auxiliary_ce_loss_weight: float = (
+        0.2  # Weighted token CE added to CRF loss (0.0 disables)
+    )
 
     # Dataset settings
     eval_size_ratio: float = 0.1  # Validation set size as ratio of training
     max_eval_samples: int = 0  # Cap eval set size (0 = no cap)
+    balanced_validation_split: bool = True
     max_sequence_length: int = 512
     training_samples_dir: str = "model/dataset/data_samples/training_samples"  # Use training samples by default, exported from Label Studio
 
@@ -84,6 +88,7 @@ class TrainingConfig:
         logging.info(f"  Max Samples: {self.max_samples}")
         logging.info(f"  Output Dir: {self.output_dir}")
         logging.info(f"  Custom Loss: {self.use_custom_loss}")
+        logging.info(f"  Auxiliary CE Loss Weight: {self.auxiliary_ce_loss_weight}")
 
 
 class EnvironmentSetup:

--- a/model/src/eval_model.py
+++ b/model/src/eval_model.py
@@ -74,6 +74,7 @@ class PIIModelLoader:
         self.tokenizer = None
         self.pii_label2id = None
         self.pii_id2label = None
+        self.coref_id2label = None
         self.device = get_device()
 
     def load_model(self):
@@ -102,16 +103,21 @@ class PIIModelLoader:
 
         # Load model config to get base model name
         config_path = Path(self.model_path) / "config.json"
+        model_type_defaults = {
+            "bert": "bert-base-cased",
+            "distilbert": "distilbert-base-cased",
+            "roberta": "roberta-base",
+            "deberta-v2": "microsoft/deberta-v3-base",
+        }
         if config_path.exists():
             with config_path.open() as f:
                 model_config = json.load(f)
-            # Try to get base model name from config
-            base_model_name = model_config.get("_name_or_path") or model_config.get(
-                "model_type", "distilbert"
-            )
-            # Convert model_type to full model name if needed
-            if base_model_name == "distilbert":
-                base_model_name = "distilbert-base-cased"
+            base_model_name = model_config.get("_name_or_path", "")
+            if not base_model_name or base_model_name in model_type_defaults:
+                model_type = model_config.get("model_type", "distilbert")
+                base_model_name = model_type_defaults.get(
+                    model_type, "microsoft/deberta-v3-base"
+                )
         else:
             base_model_name = "microsoft/deberta-v3-base"
             logging.warning(
@@ -243,13 +249,25 @@ class PIIModelLoader:
         # Run inference
         with torch.no_grad():
             outputs = self.model(**inputs)
-            # Get PII predictions
-            pii_predictions = torch.argmax(outputs["pii_logits"], dim=-1)[0]
+            if hasattr(self.model, "decode"):
+                pii_prediction_ids = self.model.decode(
+                    outputs["pii_logits"], inputs["attention_mask"]
+                )[0]
+            else:
+                pii_prediction_ids = (
+                    torch.argmax(outputs["pii_logits"], dim=-1)[0].cpu().tolist()
+                )
 
         # Convert predictions to labels
         tokens = self.tokenizer.convert_ids_to_tokens(inputs["input_ids"][0])
+        if len(pii_prediction_ids) < len(tokens):
+            pii_prediction_ids = pii_prediction_ids + [0] * (
+                len(tokens) - len(pii_prediction_ids)
+            )
+        pii_prediction_ids = pii_prediction_ids[: len(tokens)]
         predicted_labels = [
-            self.pii_id2label.get(p.item(), "O") for p in pii_predictions
+            self.pii_id2label.get(int(label_id), "O")
+            for label_id in pii_prediction_ids
         ]
 
         # Extract entities

--- a/model/src/eval_model.py
+++ b/model/src/eval_model.py
@@ -38,6 +38,23 @@ try:
 except ImportError:
     from .model import PIIDetectionModel
 
+try:
+    from model.src.checkpoint_utils import (
+        load_compatible_state_dict,
+        normalize_state_dict_keys,
+    )
+except ImportError:
+    try:
+        from src.checkpoint_utils import (
+            load_compatible_state_dict,
+            normalize_state_dict_keys,
+        )
+    except ImportError:
+        from .checkpoint_utils import (
+            load_compatible_state_dict,
+            normalize_state_dict_keys,
+        )
+
 
 # =============================================================================
 # DEVICE UTILITIES
@@ -155,13 +172,7 @@ class PIIModelLoader:
                     model_weights_path, map_location="cpu", weights_only=False
                 )
 
-            # Handle state dict that might have 'model.' prefix
-            if any(k.startswith("model.") for k in state_dict.keys()):
-                state_dict = {
-                    k.replace("model.", ""): v
-                    for k, v in state_dict.items()
-                    if k.startswith("model.")
-                }
+            state_dict = normalize_state_dict_keys(state_dict)
 
         logging.info("📋 Model configuration:")
         logging.info(f"   Base model: {base_model_name}")
@@ -188,15 +199,18 @@ class PIIModelLoader:
                 ) as f:
                     for key in f.keys():
                         state_dict[key] = f.get_tensor(key)
-                # Handle state dict that might have 'model.' prefix
-                if any(k.startswith("model.") for k in state_dict.keys()):
-                    state_dict = {
-                        k.replace("model.", ""): v
-                        for k, v in state_dict.items()
-                        if k.startswith("model.")
-                    }
+                state_dict = normalize_state_dict_keys(state_dict)
 
-            self.model.load_state_dict(state_dict, strict=False)
+            load_info = load_compatible_state_dict(
+                self.model,
+                state_dict,
+                source=str(model_weights_path),
+            )
+            if load_info.unexpected_keys:
+                logging.warning(
+                    "⚠️  Ignoring unexpected checkpoint keys: %s",
+                    load_info.unexpected_keys[:20],
+                )
             logging.info("✅ Model weights loaded")
         else:
             logging.warning(

--- a/model/src/eval_model.py
+++ b/model/src/eval_model.py
@@ -300,17 +300,6 @@ class PIIModelLoader:
             ):
                 continue
 
-            # Skip punctuation-only tokens when continuing an entity
-            # This prevents punctuation from being included in entities
-            token_text = (
-                text[offset[0].item() : offset[1].item()]
-                if offset[0].item() < len(text)
-                else ""
-            )
-            is_punctuation_only = token_text.strip() and all(
-                c in ",.;:!?)]}" for c in token_text.strip()
-            )
-
             # Check if this is a PII token
             if label.startswith("B-"):
                 # Save previous entity if exists
@@ -330,24 +319,19 @@ class PIIModelLoader:
                             )
                         )
 
-                # Start new entity (skip if it's punctuation-only)
-                if not is_punctuation_only:
-                    current_label = label[2:]  # Remove "B-" prefix
-                    current_start = offset[0].item()
-                    current_end = offset[1].item()
-                    current_entity = token
-                else:
-                    current_entity = None
-                    current_label = None
+                current_label = label[2:]  # Remove "B-" prefix
+                current_start = offset[0].item()
+                current_end = offset[1].item()
+                current_entity = token
 
             elif label.startswith("I-") and current_entity is not None:
-                # Continue current entity (only if same label and not punctuation-only)
-                if (
-                    current_label == label[2:] and not is_punctuation_only
-                ):  # Check label matches
+                # Continue current entity if the label matches. Punctuation inside
+                # the entity span, such as dots in emails/URLs, is preserved here
+                # and only trailing sentence punctuation is stripped at finalization.
+                if current_label == label[2:]:
                     current_end = offset[1].item()
                 else:
-                    # Different label or punctuation - save previous and start new (if not punctuation)
+                    # Different label - save previous and start new
                     entity_text = text[current_start:current_end]
                     # Strip trailing punctuation
                     entity_text, chars_stripped = strip_trailing_punctuation(
@@ -363,13 +347,10 @@ class PIIModelLoader:
                             )
                         )
 
-                    if not is_punctuation_only:
-                        current_label = label[2:]
-                        current_start = offset[0].item()
-                        current_end = offset[1].item()
-                    else:
-                        current_entity = None
-                        current_label = None
+                    current_label = label[2:]
+                    current_start = offset[0].item()
+                    current_end = offset[1].item()
+                    current_entity = token
 
             elif current_entity is not None:  # "O" label or entity ended
                 # Save previous entity if exists

--- a/model/src/eval_model.py
+++ b/model/src/eval_model.py
@@ -266,8 +266,7 @@ class PIIModelLoader:
             )
         pii_prediction_ids = pii_prediction_ids[: len(tokens)]
         predicted_labels = [
-            self.pii_id2label.get(int(label_id), "O")
-            for label_id in pii_prediction_ids
+            self.pii_id2label.get(int(label_id), "O") for label_id in pii_prediction_ids
         ]
 
         # Extract entities

--- a/model/src/eval_model_detailed.py
+++ b/model/src/eval_model_detailed.py
@@ -279,7 +279,9 @@ class DetailedPIIModelLoader:
             if coref_logits is not None:
                 coref_logits = coref_logits[0]  # [seq_len, num_coref_labels]
                 coref_predictions = torch.argmax(coref_logits, dim=-1)  # [seq_len]
-                coref_probs = F.softmax(coref_logits, dim=-1)  # [seq_len, num_coref_labels]
+                coref_probs = F.softmax(
+                    coref_logits, dim=-1
+                )  # [seq_len, num_coref_labels]
             else:
                 coref_predictions = None
                 coref_probs = None
@@ -292,8 +294,7 @@ class DetailedPIIModelLoader:
             )
         pii_prediction_ids = pii_prediction_ids[: len(tokens)]
         pii_pred_labels = [
-            self.pii_id2label.get(int(label_id), "O")
-            for label_id in pii_prediction_ids
+            self.pii_id2label.get(int(label_id), "O") for label_id in pii_prediction_ids
         ]
         pii_pred_ids = [int(label_id) for label_id in pii_prediction_ids]
         coref_pred_ids = (

--- a/model/src/eval_model_detailed.py
+++ b/model/src/eval_model_detailed.py
@@ -80,6 +80,7 @@ class DetailedPIIModelLoader:
         self.tokenizer = None
         self.pii_label2id = None
         self.pii_id2label = None
+        self.coref_id2label = None
         self.device = get_device()
 
     def load_model(self):
@@ -108,16 +109,21 @@ class DetailedPIIModelLoader:
 
         # Load model config to get base model name
         config_path = Path(self.model_path) / "config.json"
+        model_type_defaults = {
+            "bert": "bert-base-cased",
+            "distilbert": "distilbert-base-cased",
+            "roberta": "roberta-base",
+            "deberta-v2": "microsoft/deberta-v3-base",
+        }
         if config_path.exists():
             with config_path.open() as f:
                 model_config = json.load(f)
-            # Try to get base model name from config
-            base_model_name = model_config.get("_name_or_path") or model_config.get(
-                "model_type", "distilbert"
-            )
-            # Convert model_type to full model name if needed
-            if base_model_name == "distilbert":
-                base_model_name = "distilbert-base-cased"
+            base_model_name = model_config.get("_name_or_path", "")
+            if not base_model_name or base_model_name in model_type_defaults:
+                model_type = model_config.get("model_type", "distilbert")
+                base_model_name = model_type_defaults.get(
+                    model_type, "microsoft/deberta-v3-base"
+                )
         else:
             base_model_name = "microsoft/deberta-v3-base"
             logging.warning(
@@ -259,21 +265,42 @@ class DetailedPIIModelLoader:
             outputs = self.model(**inputs)
             # Get PII logits and predictions
             pii_logits = outputs["pii_logits"][0]  # [seq_len, num_labels]
-            pii_predictions = torch.argmax(pii_logits, dim=-1)  # [seq_len]
+            if hasattr(self.model, "decode"):
+                pii_prediction_ids = self.model.decode(
+                    outputs["pii_logits"], inputs["attention_mask"]
+                )[0]
+            else:
+                pii_prediction_ids = torch.argmax(pii_logits, dim=-1).cpu().tolist()
             pii_probs = F.softmax(pii_logits, dim=-1)  # [seq_len, num_labels]
 
-            # Get co-reference logits and predictions
-            coref_logits = outputs["coref_logits"][0]  # [seq_len, num_coref_labels]
-            coref_predictions = torch.argmax(coref_logits, dim=-1)  # [seq_len]
-            coref_probs = F.softmax(coref_logits, dim=-1)  # [seq_len, num_coref_labels]
+            # Older multi-task checkpoints may expose co-reference logits. Current
+            # PII-only checkpoints do not, so keep the detailed script usable.
+            coref_logits = outputs.get("coref_logits")
+            if coref_logits is not None:
+                coref_logits = coref_logits[0]  # [seq_len, num_coref_labels]
+                coref_predictions = torch.argmax(coref_logits, dim=-1)  # [seq_len]
+                coref_probs = F.softmax(coref_logits, dim=-1)  # [seq_len, num_coref_labels]
+            else:
+                coref_predictions = None
+                coref_probs = None
 
         # Convert to lists
         tokens = self.tokenizer.convert_ids_to_tokens(inputs["input_ids"][0])
+        if len(pii_prediction_ids) < len(tokens):
+            pii_prediction_ids = pii_prediction_ids + [0] * (
+                len(tokens) - len(pii_prediction_ids)
+            )
+        pii_prediction_ids = pii_prediction_ids[: len(tokens)]
         pii_pred_labels = [
-            self.pii_id2label.get(p.item(), "O") for p in pii_predictions
+            self.pii_id2label.get(int(label_id), "O")
+            for label_id in pii_prediction_ids
         ]
-        pii_pred_ids = [p.item() for p in pii_predictions]
-        coref_pred_ids = [p.item() for p in coref_predictions]
+        pii_pred_ids = [int(label_id) for label_id in pii_prediction_ids]
+        coref_pred_ids = (
+            [p.item() for p in coref_predictions]
+            if coref_predictions is not None
+            else [0] * len(tokens)
+        )
 
         # Get top-k predictions for PII
         pii_top_k_list = []
@@ -293,25 +320,35 @@ class DetailedPIIModelLoader:
 
         # Get top-k predictions for co-reference
         coref_top_k_list = []
-        for i in range(len(tokens)):
-            top_k_probs, top_k_indices = torch.topk(
-                coref_probs[i], k=min(top_k, len(self.coref_id2label))
-            )
-            top_k_items = [
-                {
-                    "label": self.coref_id2label.get(
-                        idx.item(), f"CLUSTER_{idx.item()}"
-                    ),
-                    "label_id": idx.item(),
-                    "probability": prob.item(),
-                }
-                for prob, idx in zip(top_k_probs, top_k_indices, strict=True)
+        if coref_probs is not None and self.coref_id2label:
+            for i in range(len(tokens)):
+                top_k_probs, top_k_indices = torch.topk(
+                    coref_probs[i], k=min(top_k, len(self.coref_id2label))
+                )
+                top_k_items = [
+                    {
+                        "label": self.coref_id2label.get(
+                            idx.item(), f"CLUSTER_{idx.item()}"
+                        ),
+                        "label_id": idx.item(),
+                        "probability": prob.item(),
+                    }
+                    for prob, idx in zip(top_k_probs, top_k_indices, strict=True)
+                ]
+                coref_top_k_list.append(top_k_items)
+        else:
+            coref_top_k_list = [
+                [{"label": "NO_COREF", "label_id": 0, "probability": 1.0}]
+                for _ in tokens
             ]
-            coref_top_k_list.append(top_k_items)
 
         # Convert probabilities to lists
         pii_prob_list = [probs.cpu().tolist() for probs in pii_probs]
-        coref_prob_list = [probs.cpu().tolist() for probs in coref_probs]
+        coref_prob_list = (
+            [probs.cpu().tolist() for probs in coref_probs]
+            if coref_probs is not None
+            else [[1.0] for _ in tokens]
+        )
 
         end_time = time.perf_counter()
         inference_time_ms = (end_time - start_time) * 1000
@@ -331,7 +368,8 @@ class DetailedPIIModelLoader:
 
         if show_logits:
             result["pii_logits"] = pii_logits.cpu().tolist()
-            result["coref_logits"] = coref_logits.cpu().tolist()
+            if coref_logits is not None:
+                result["coref_logits"] = coref_logits.cpu().tolist()
 
         return result
 

--- a/model/src/eval_model_detailed.py
+++ b/model/src/eval_model_detailed.py
@@ -44,6 +44,23 @@ try:
 except ImportError:
     from model import PIIDetectionModel
 
+try:
+    from model.src.checkpoint_utils import (
+        load_compatible_state_dict,
+        normalize_state_dict_keys,
+    )
+except ImportError:
+    try:
+        from src.checkpoint_utils import (
+            load_compatible_state_dict,
+            normalize_state_dict_keys,
+        )
+    except ImportError:
+        from checkpoint_utils import (
+            load_compatible_state_dict,
+            normalize_state_dict_keys,
+        )
+
 
 # =============================================================================
 # DEVICE UTILITIES
@@ -161,13 +178,7 @@ class DetailedPIIModelLoader:
                     model_weights_path, map_location="cpu", weights_only=False
                 )
 
-            # Handle state dict that might have 'model.' prefix
-            if any(k.startswith("model.") for k in state_dict.keys()):
-                state_dict = {
-                    k.replace("model.", ""): v
-                    for k, v in state_dict.items()
-                    if k.startswith("model.")
-                }
+            state_dict = normalize_state_dict_keys(state_dict)
 
         logging.info("📋 Model configuration:")
         logging.info(f"   Base model: {base_model_name}")
@@ -194,15 +205,18 @@ class DetailedPIIModelLoader:
                 ) as f:
                     for key in f.keys():
                         state_dict[key] = f.get_tensor(key)
-                # Handle state dict that might have 'model.' prefix
-                if any(k.startswith("model.") for k in state_dict.keys()):
-                    state_dict = {
-                        k.replace("model.", ""): v
-                        for k, v in state_dict.items()
-                        if k.startswith("model.")
-                    }
+                state_dict = normalize_state_dict_keys(state_dict)
 
-            self.model.load_state_dict(state_dict, strict=False)
+            load_info = load_compatible_state_dict(
+                self.model,
+                state_dict,
+                source=str(model_weights_path),
+            )
+            if load_info.unexpected_keys:
+                logging.warning(
+                    "⚠️  Ignoring unexpected checkpoint keys: %s",
+                    load_info.unexpected_keys[:20],
+                )
             logging.info("✅ Model weights loaded")
         else:
             logging.warning(

--- a/model/src/preprocessing.py
+++ b/model/src/preprocessing.py
@@ -76,6 +76,10 @@ class PIILabels:
 class DatasetProcessor:
     """Handles dataset loading and processing from local JSON files."""
 
+    # Coreference marker labels used in Label Studio annotations.
+    # These are not PII entities and should not be included in the NER target.
+    _COREFERENCE_LABELS = {"PRONOUN", "REFERENCE", "MENTION", "pronoun", "reference"}
+
     def __init__(self, config):
         """
         Initialize dataset processor.
@@ -155,6 +159,10 @@ class DatasetProcessor:
                         }
                     )
 
+            def is_pii_entity(entity: dict) -> bool:
+                label = entity.get("label")
+                return bool(label) and label not in self._COREFERENCE_LABELS
+
             # Build privacy_mask from entities
             privacy_mask = []
 
@@ -180,9 +188,9 @@ class DatasetProcessor:
 
                 main_entity = entities[main_entity_id]
 
-                # Add main entity to privacy_mask (skip if no label, e.g. coreference span markers)
+                # Add main entity to privacy_mask (skip if no label or a coreference marker)
                 if main_entity_id not in processed_entities:
-                    if main_entity["label"]:
+                    if is_pii_entity(main_entity):
                         privacy_mask.append(
                             {
                                 "value": main_entity["text"],
@@ -213,7 +221,7 @@ class DatasetProcessor:
 
             # Add remaining entities (not part of coreferences) to privacy_mask
             for entity_id, entity in entities.items():
-                if entity_id not in processed_entities and entity["label"]:
+                if entity_id not in processed_entities and is_pii_entity(entity):
                     privacy_mask.append(
                         {
                             "value": entity["text"],
@@ -235,10 +243,6 @@ class DatasetProcessor:
         except Exception as e:
             logging.debug(f"Failed to convert Label Studio sample in {file_name}: {e}")
             return None
-
-    # Coreference marker labels used in Label Studio annotations.
-    # These are not PII entities and should not trigger non-standard label filtering.
-    _COREFERENCE_LABELS = {"PRONOUN", "REFERENCE", "MENTION", "pronoun", "reference"}
 
     def _has_non_standard_labels(self, sample: dict) -> bool:
         """
@@ -437,6 +441,100 @@ class DatasetProcessor:
         logging.info(f"Loaded {len(samples)} ai4privacy samples")
         return samples
 
+    def _sample_entity_types(self, sample: dict) -> set[str]:
+        """Return entity types present in a tokenized sample."""
+        entity_types = set()
+        for label_id in sample.get("pii_labels", []):
+            if label_id in (-100, 0):
+                continue
+            label = self.id2label.get(int(label_id), "O")
+            if label.startswith(("B-", "I-")):
+                entity_types.add(label[2:])
+        return entity_types
+
+    def _split_train_validation(
+        self, formatted_samples: list[dict]
+    ) -> tuple[list[dict], list[dict]]:
+        """Create a deterministic, rare-label-aware train/validation split."""
+        if not formatted_samples:
+            return [], []
+
+        eval_ratio = self.config.eval_size_ratio
+        if eval_ratio <= 0:
+            return formatted_samples, []
+
+        val_count = int(len(formatted_samples) * eval_ratio)
+        val_count = min(max(val_count, 1), len(formatted_samples) - 1)
+
+        rng = random.Random(self.config.seed)
+        indexed_samples = list(enumerate(formatted_samples))
+        rng.shuffle(indexed_samples)
+
+        if not self.config.balanced_validation_split:
+            val_indices = {idx for idx, _ in indexed_samples[:val_count]}
+        else:
+            sample_labels = {
+                idx: self._sample_entity_types(sample) for idx, sample in indexed_samples
+            }
+            label_frequency: Counter = Counter()
+            for labels in sample_labels.values():
+                label_frequency.update(labels)
+
+            label_targets = {
+                label: max(1, int(round(count * eval_ratio)))
+                for label, count in label_frequency.items()
+            }
+            val_label_counts: Counter = Counter()
+            val_indices = set()
+
+            def rarity_score(item: tuple[int, dict]) -> tuple[float, float]:
+                idx, _sample = item
+                labels = sample_labels[idx]
+                if not labels:
+                    return (0.0, rng.random())
+                return (
+                    sum(1.0 / label_frequency[label] for label in labels),
+                    rng.random(),
+                )
+
+            for idx, _sample in sorted(
+                indexed_samples, key=rarity_score, reverse=True
+            ):
+                if len(val_indices) >= val_count:
+                    break
+                labels = sample_labels[idx]
+                if not labels:
+                    continue
+                if any(
+                    val_label_counts[label] < label_targets[label] for label in labels
+                ):
+                    val_indices.add(idx)
+                    val_label_counts.update(labels)
+
+            for idx, _sample in indexed_samples:
+                if len(val_indices) >= val_count:
+                    break
+                val_indices.add(idx)
+
+            covered_labels = sum(
+                1 for label in label_frequency if val_label_counts[label] > 0
+            )
+            logging.info(
+                "Balanced validation split: %d/%d entity types represented",
+                covered_labels,
+                len(label_frequency),
+            )
+
+        train_samples = [
+            sample
+            for idx, sample in enumerate(formatted_samples)
+            if idx not in val_indices
+        ]
+        val_samples = [
+            sample for idx, sample in enumerate(formatted_samples) if idx in val_indices
+        ]
+        return train_samples, val_samples
+
     def prepare_datasets(
         self, subsample_count: int = 0
     ) -> tuple[Dataset, Dataset, dict, dict]:
@@ -455,9 +553,10 @@ class DatasetProcessor:
         all_samples = [s for s in all_samples if s is not None]
 
         # Subsample local dataset if requested
-        if subsample_count > 0 and len(all_samples) > subsample_count:
+        sample_limit = subsample_count or self.config.max_samples
+        if sample_limit > 0 and len(all_samples) > sample_limit:
             random.Random(self.config.seed).shuffle(all_samples)
-            all_samples = all_samples[:subsample_count]
+            all_samples = all_samples[:sample_limit]
             logging.info(f"Local dataset: {len(all_samples)} samples (capped)")
 
         # Add ai4privacy samples if configured (-1 = none, 0 = all, N = limit)
@@ -508,14 +607,9 @@ class DatasetProcessor:
         if len(formatted_samples) == 0:
             raise ValueError("No samples could be tokenized!")
 
-        # Shuffle before splitting to prevent ordered-batch bias
-        random.seed(42)
-        random.shuffle(formatted_samples)
-
-        # Split into train and validation
-        split_idx = int(len(formatted_samples) * (1 - self.config.eval_size_ratio))
-        train_samples = formatted_samples[:split_idx]
-        val_samples = formatted_samples[split_idx:]
+        # Split into train and validation. The default split is rare-label aware so
+        # macro F1 and best-checkpoint selection are less sensitive to common labels.
+        train_samples, val_samples = self._split_train_validation(formatted_samples)
 
         # Create HuggingFace datasets
         train_dataset = Dataset.from_list(train_samples)

--- a/model/src/preprocessing.py
+++ b/model/src/preprocessing.py
@@ -474,7 +474,8 @@ class DatasetProcessor:
             val_indices = {idx for idx, _ in indexed_samples[:val_count]}
         else:
             sample_labels = {
-                idx: self._sample_entity_types(sample) for idx, sample in indexed_samples
+                idx: self._sample_entity_types(sample)
+                for idx, sample in indexed_samples
             }
             label_frequency: Counter = Counter()
             for labels in sample_labels.values():
@@ -497,9 +498,7 @@ class DatasetProcessor:
                     rng.random(),
                 )
 
-            for idx, _sample in sorted(
-                indexed_samples, key=rarity_score, reverse=True
-            ):
+            for idx, _sample in sorted(indexed_samples, key=rarity_score, reverse=True):
                 if len(val_indices) >= val_count:
                     break
                 labels = sample_labels[idx]

--- a/model/src/quantitize.py
+++ b/model/src/quantitize.py
@@ -117,6 +117,7 @@ def load_model(
     config_path = model_path / "config.json"
     # Map model_type shortnames to full HuggingFace model identifiers
     model_type_defaults = {
+        "bert": "bert-base-cased",
         "distilbert": "distilbert-base-cased",
         "roberta": "roberta-base",
         "deberta-v2": "microsoft/deberta-v3-base",

--- a/model/src/quantitize.py
+++ b/model/src/quantitize.py
@@ -44,6 +44,11 @@ except ImportError:
     sys.path.insert(0, str(Path(__file__).parent))
     from model_signing import sign_trained_model
 
+try:
+    from model.src.checkpoint_utils import load_compatible_state_dict
+except ImportError:
+    from checkpoint_utils import load_compatible_state_dict
+
 # Define command-line flags
 FLAGS = flags.FLAGS
 
@@ -175,14 +180,16 @@ def load_model(
                 model_weights_path, map_location="cpu", weights_only=False
             )
 
-        # Handle state dict that might have 'model.' prefix
-        if any(k.startswith("model.") for k in state_dict.keys()):
-            state_dict = {
-                k.replace("model.", ""): v
-                for k, v in state_dict.items()
-                if k.startswith("model.")
-            }
-        model.load_state_dict(state_dict, strict=False)
+        load_info = load_compatible_state_dict(
+            model,
+            state_dict,
+            source=str(model_weights_path),
+        )
+        if load_info.unexpected_keys:
+            logging.warning(
+                "⚠️  Ignoring unexpected checkpoint keys: %s",
+                load_info.unexpected_keys[:20],
+            )
         logging.info("✅ Model weights loaded")
     else:
         raise FileNotFoundError(f"Model weights not found in {model_path}")

--- a/model/src/trainer.py
+++ b/model/src/trainer.py
@@ -45,18 +45,26 @@ except ImportError:
 class PIIModelTrainer(Trainer):
     """Custom Trainer for PII detection."""
 
-    def __init__(self, pii_loss_fn=None, layerwise_lr_decay=1.0, **kwargs):
+    def __init__(
+        self,
+        pii_loss_fn=None,
+        layerwise_lr_decay=1.0,
+        auxiliary_ce_loss_weight=0.0,
+        **kwargs,
+    ):
         """
         Initialize PII trainer.
 
         Args:
             pii_loss_fn: Loss function for PII detection
             layerwise_lr_decay: Multiplicative LR decay per encoder layer (1.0 = disabled)
+            auxiliary_ce_loss_weight: Weight for token CE added to the CRF loss
             **kwargs: Additional arguments for Trainer
         """
         super().__init__(**kwargs)
         self.pii_loss_fn = pii_loss_fn
         self.layerwise_lr_decay = layerwise_lr_decay
+        self.auxiliary_ce_loss_weight = auxiliary_ce_loss_weight
 
     def create_optimizer(self):
         """Create optimizer with layer-wise learning rate decay for the encoder."""
@@ -219,6 +227,12 @@ class PIIModelTrainer(Trainer):
         # Use CRF loss for PII if available, otherwise fall back
         if "crf_loss" in outputs:
             loss = outputs["crf_loss"]
+            if (
+                self.pii_loss_fn is not None
+                and self.auxiliary_ce_loss_weight > 0
+            ):
+                token_loss = self.pii_loss_fn(outputs["pii_logits"], pii_labels)
+                loss = loss + self.auxiliary_ce_loss_weight * token_loss
         elif self.pii_loss_fn is not None:
             loss = self.pii_loss_fn(outputs["pii_logits"], pii_labels)
         else:
@@ -259,7 +273,26 @@ class PIIModelTrainer(Trainer):
         pii_logits = outputs.get("pii_logits")
         pii_labels = inputs.get("pii_labels")
 
-        predictions = pii_logits.detach().cpu() if pii_logits is not None else None
+        predictions = None
+        if pii_logits is not None:
+            attention_mask = inputs.get("attention_mask")
+            if hasattr(model, "decode") and attention_mask is not None:
+                decoded_paths = model.decode(pii_logits, attention_mask)
+                decoded_predictions = torch.zeros(
+                    pii_logits.shape[:2],
+                    dtype=torch.long,
+                    device=pii_logits.device,
+                )
+                for row_idx, path in enumerate(decoded_paths):
+                    path_len = min(len(path), decoded_predictions.shape[1])
+                    decoded_predictions[row_idx, :path_len] = torch.tensor(
+                        path[:path_len],
+                        dtype=torch.long,
+                        device=pii_logits.device,
+                    )
+                predictions = decoded_predictions.detach().cpu()
+            else:
+                predictions = pii_logits.detach().cpu()
         labels = pii_labels.detach().cpu() if pii_labels is not None else None
 
         return (loss, predictions, labels)
@@ -350,8 +383,18 @@ class PIITrainer:
             pii_predictions = predictions
             pii_labels = label_ids
 
-        # PII detection metrics using seqeval (entity-level)
-        pii_preds = np.argmax(pii_predictions, axis=2)
+        # PII detection metrics using seqeval (entity-level). During CRF training,
+        # prediction_step returns decoded label IDs. Older/non-CRF paths may still
+        # return logits, so keep both formats supported.
+        pii_predictions = np.asarray(pii_predictions)
+        if pii_predictions.ndim == 3:
+            pii_preds = np.argmax(pii_predictions, axis=2)
+        elif pii_predictions.ndim == 2:
+            pii_preds = pii_predictions.astype(np.int64)
+        else:
+            raise ValueError(
+                f"Unsupported PII prediction shape: {pii_predictions.shape}"
+            )
 
         # Build list-of-lists of BIO tag strings, skipping padding (-100)
         true_labels = []
@@ -424,6 +467,24 @@ class PIITrainer:
                 metrics[f"eval_pii_recall_{safe_avg}"] = report[avg_type].get(
                     "recall", 0.0
                 )
+
+        # Backward-compatible aliases used by summaries and best-model selection.
+        if "macro avg" in report:
+            metrics["eval_pii_f1_macro"] = report["macro avg"].get("f1-score", 0.0)
+            metrics["eval_pii_precision_macro"] = report["macro avg"].get(
+                "precision", 0.0
+            )
+            metrics["eval_pii_recall_macro"] = report["macro avg"].get("recall", 0.0)
+        if "weighted avg" in report:
+            metrics["eval_pii_f1_weighted"] = report["weighted avg"].get(
+                "f1-score", 0.0
+            )
+            metrics["eval_pii_precision_weighted"] = report["weighted avg"].get(
+                "precision", 0.0
+            )
+            metrics["eval_pii_recall_weighted"] = report["weighted avg"].get(
+                "recall", 0.0
+            )
 
         return metrics
 
@@ -511,7 +572,7 @@ class PIITrainer:
             eval_strategy="epoch",
             save_strategy="epoch",
             load_best_model_at_end=True,
-            metric_for_best_model="eval_pii_f1",
+            metric_for_best_model="eval_pii_f1_macro",
             greater_is_better=True,
             report_to=None,
             save_total_limit=3,
@@ -548,6 +609,7 @@ class PIITrainer:
             compute_metrics=self.compute_metrics,
             pii_loss_fn=self.pii_loss_fn,
             layerwise_lr_decay=self.config.layerwise_lr_decay,
+            auxiliary_ce_loss_weight=self.config.auxiliary_ce_loss_weight,
             callbacks=callbacks if callbacks else None,
         )
 
@@ -563,6 +625,8 @@ class PIITrainer:
 
         # Save
         trainer.save_model()
+        self.model.encoder.config._name_or_path = self.config.model_name
+        self.model.encoder.config.save_pretrained(self.config.output_dir)
         self.tokenizer.save_pretrained(self.config.output_dir)
         logging.info(
             f"\n✅ Training completed. Model saved to {self.config.output_dir}"

--- a/model/src/trainer.py
+++ b/model/src/trainer.py
@@ -227,10 +227,7 @@ class PIIModelTrainer(Trainer):
         # Use CRF loss for PII if available, otherwise fall back
         if "crf_loss" in outputs:
             loss = outputs["crf_loss"]
-            if (
-                self.pii_loss_fn is not None
-                and self.auxiliary_ce_loss_weight > 0
-            ):
+            if self.pii_loss_fn is not None and self.auxiliary_ce_loss_weight > 0:
                 token_loss = self.pii_loss_fn(outputs["pii_logits"], pii_labels)
                 loss = loss + self.auxiliary_ce_loss_weight * token_loss
         elif self.pii_loss_fn is not None:

--- a/src/backend/pii/detectors/onnx_model_detector.go
+++ b/src/backend/pii/detectors/onnx_model_detector.go
@@ -424,6 +424,13 @@ func tokenStartsAtPreviousEnd(tokenIndex int, currentTokens []int, offsets []tok
 	return offsets[previousTokenIndex][1] == offsets[tokenIndex][0]
 }
 
+func tokenTextAt(originalText string, offsets []tokenizers.Offset, index int) string {
+	if index >= len(offsets) || offsets[index][0] >= uint(len(originalText)) || offsets[index][1] > uint(len(originalText)) {
+		return ""
+	}
+	return originalText[offsets[index][0]:offsets[index][1]]
+}
+
 func (d *ONNXModelDetectorSimple) decodedTokenLabel(index int, outputData []float32, bestLabels []int) (string, float64) {
 	startIdx := index * d.numPIILabels
 	endIdx := (index + 1) * d.numPIILabels
@@ -445,10 +452,131 @@ func (d *ONNXModelDetectorSimple) decodedTokenLabel(index int, outputData []floa
 	return d.classifyToken(tokenLogits)
 }
 
+type decodedEntityToken struct {
+	index       int
+	tokenID     uint32
+	text        string
+	label       string
+	baseLabel   string
+	confidence  float64
+	isBeginning bool
+	isInside    bool
+}
+
+func (d *ONNXModelDetectorSimple) decodeEntityToken(
+	index int,
+	tokenID uint32,
+	originalText string,
+	offsets []tokenizers.Offset,
+	outputData []float32,
+	bestLabels []int,
+	currentEntity *Entity,
+) decodedEntityToken {
+	label, confidence := d.decodedTokenLabel(index, outputData, bestLabels)
+	tokenText := tokenTextAt(originalText, offsets, index)
+
+	if confidence < d.entityConfidenceThreshold {
+		label = "O"
+	}
+	label, confidence = d.bridgeJoinerToken(index, tokenText, label, confidence, outputData, bestLabels, currentEntity)
+
+	baseLabel, isBeginning, isInside := splitBIOLabel(label)
+	return decodedEntityToken{
+		index:       index,
+		tokenID:     tokenID,
+		text:        tokenText,
+		label:       label,
+		baseLabel:   baseLabel,
+		confidence:  confidence,
+		isBeginning: isBeginning,
+		isInside:    isInside,
+	}
+}
+
+func (d *ONNXModelDetectorSimple) bridgeJoinerToken(
+	index int,
+	tokenText string,
+	label string,
+	confidence float64,
+	outputData []float32,
+	bestLabels []int,
+	currentEntity *Entity,
+) (string, float64) {
+	if label != "O" || currentEntity == nil || !isEntityJoinerToken(tokenText) {
+		return label, confidence
+	}
+
+	nextLabel, nextConfidence := d.decodedTokenLabel(index+1, outputData, bestLabels)
+	nextBaseLabel, nextIsBeginning, nextIsInside := splitBIOLabel(nextLabel)
+	if nextConfidence >= d.entityConfidenceThreshold &&
+		(nextIsBeginning || nextIsInside) &&
+		nextBaseLabel == currentEntity.Label {
+		return "I-" + currentEntity.Label, currentEntity.Confidence
+	}
+
+	return label, confidence
+}
+
+type entityGroupingState struct {
+	currentEntity *Entity
+	currentTokens []int
+	entities      []Entity
+}
+
+func (s *entityGroupingState) consume(
+	d *ONNXModelDetectorSimple,
+	token decodedEntityToken,
+	originalText string,
+	offsets []tokenizers.Offset,
+) {
+	isSameCompactEntity := token.label != "O" &&
+		s.currentEntity != nil &&
+		s.currentEntity.Label == token.baseLabel &&
+		tokenStartsAtPreviousEnd(token.index, s.currentTokens, offsets)
+
+	switch {
+	case token.label != "O" && s.currentEntity != nil && s.currentEntity.Label == token.baseLabel && (token.isInside || isSameCompactEntity):
+		// Continue current entity. Same-label B tags immediately after a
+		// joiner token are treated as continuation so emails like
+		// "jonathan.reyes@example.com" do not fragment.
+		s.currentTokens = append(s.currentTokens, token.index)
+		s.currentEntity.Confidence = (s.currentEntity.Confidence + token.confidence) / 2
+	case token.label != "O" && (token.isBeginning || s.currentEntity == nil):
+		s.finishCurrent(d, originalText, offsets)
+		s.currentEntity = &Entity{
+			Label:      token.baseLabel,
+			Confidence: token.confidence,
+		}
+		s.currentTokens = []int{token.index}
+	default:
+		s.finishCurrent(d, originalText, offsets)
+	}
+}
+
+func (s *entityGroupingState) finishCurrent(d *ONNXModelDetectorSimple, originalText string, offsets []tokenizers.Offset) {
+	if s.currentEntity == nil {
+		return
+	}
+
+	d.finalizeEntity(s.currentEntity, s.currentTokens, originalText, offsets)
+	s.entities = append(s.entities, *s.currentEntity)
+	s.currentEntity = nil
+	s.currentTokens = nil
+}
+
+func filterEmptyEntities(entities []Entity) []Entity {
+	filtered := entities[:0]
+	for _, e := range entities {
+		if e.Text != "" {
+			filtered = append(filtered, e)
+		}
+	}
+	return filtered
+}
+
 // processOutputInline converts model output to entities (inline to avoid compilation issues)
 func (d *ONNXModelDetectorSimple) processOutputInline(originalText string, tokenIDs []uint32, offsets []tokenizers.Offset) []Entity {
 	outputData := d.outputTensor.GetData()
-	entities := []Entity{}
 
 	// Ensure we don't process more tokens than we have
 	numTokens := len(tokenIDs)
@@ -465,8 +593,7 @@ func (d *ONNXModelDetectorSimple) processOutputInline(originalText string, token
 	}
 
 	// Group consecutive tokens with same label (B-PREFIX, I-PREFIX pattern)
-	var currentEntity *Entity
-	var currentTokens []int
+	state := entityGroupingState{}
 
 	// Process each token
 	for i := 0; i < numTokens; i++ {
@@ -478,90 +605,18 @@ func (d *ONNXModelDetectorSimple) processOutputInline(originalText string, token
 			break // Reached end of output data
 		}
 
-		// Get label and confidence
-		label, confidence := d.decodedTokenLabel(i, outputData, bestLabels)
-
-		// Log token details
-		tokenText := ""
-		if i < len(offsets) && offsets[i][0] < uint(len(originalText)) && offsets[i][1] <= uint(len(originalText)) {
-			tokenText = originalText[offsets[i][0]:offsets[i][1]]
-		}
+		token := d.decodeEntityToken(i, tokenIDs[i], originalText, offsets, outputData, bestLabels, state.currentEntity)
 		fmt.Printf("[ONNX Model Response] Token %d: id=%d text=%q offset=(%d,%d) label=%q confidence=%.4f\n",
-			i, tokenIDs[i], tokenText, offsets[i][0], offsets[i][1], label, confidence)
+			i, token.tokenID, token.text, offsets[i][0], offsets[i][1], token.label, token.confidence)
 
-		// Only process tokens with reasonable confidence
-		if confidence < d.entityConfidenceThreshold {
-			label = "O"
-		}
-
-		// Punctuation inside compact entities such as emails and URLs may be
-		// decoded as O by older models. If it is sandwiched between tokens of
-		// the same entity label, keep it as a bridge and let finalizeEntity trim
-		// true trailing sentence punctuation.
-		if label == "O" && currentEntity != nil && isEntityJoinerToken(tokenText) {
-			nextLabel, nextConfidence := d.decodedTokenLabel(i+1, outputData, bestLabels)
-			nextBaseLabel, nextIsBeginning, nextIsInside := splitBIOLabel(nextLabel)
-			if nextConfidence >= d.entityConfidenceThreshold &&
-				(nextIsBeginning || nextIsInside) &&
-				nextBaseLabel == currentEntity.Label {
-				label = "I-" + currentEntity.Label
-				confidence = currentEntity.Confidence
-			}
-		}
-
-		// Handle B-PREFIX (beginning) and I-PREFIX (inside) labels
-		baseLabel, isBeginning, isInside := splitBIOLabel(label)
-		isSameCompactEntity := label != "O" &&
-			currentEntity != nil &&
-			currentEntity.Label == baseLabel &&
-			tokenStartsAtPreviousEnd(i, currentTokens, offsets)
-
-		// Handle different entity states using switch for better readability
-		switch {
-		case label != "O" && currentEntity != nil && currentEntity.Label == baseLabel && (isInside || isSameCompactEntity):
-			// Continue current entity. Same-label B tags immediately after a
-			// joiner token are treated as continuation so emails like
-			// "jonathan.reyes@example.com" do not fragment.
-			currentTokens = append(currentTokens, i)
-			currentEntity.Confidence = (currentEntity.Confidence + confidence) / 2
-		case label != "O" && (isBeginning || currentEntity == nil):
-			// Finish previous entity if exists
-			if currentEntity != nil {
-				d.finalizeEntity(currentEntity, currentTokens, originalText, offsets)
-				entities = append(entities, *currentEntity)
-			}
-
-			// Start new entity
-			currentEntity = &Entity{
-				Label:      baseLabel,
-				Confidence: confidence,
-			}
-			currentTokens = []int{i}
-		default:
-			// Finish current entity if exists
-			if currentEntity != nil {
-				d.finalizeEntity(currentEntity, currentTokens, originalText, offsets)
-				entities = append(entities, *currentEntity)
-				currentEntity = nil
-				currentTokens = nil
-			}
-		}
+		state.consume(d, token, originalText, offsets)
 	}
 
 	// Finish last entity if exists
-	if currentEntity != nil {
-		d.finalizeEntity(currentEntity, currentTokens, originalText, offsets)
-		entities = append(entities, *currentEntity)
-	}
+	state.finishCurrent(d, originalText, offsets)
 
 	// Filter out entities with empty text (e.g. from special tokens like [CLS]/[SEP])
-	filtered := entities[:0]
-	for _, e := range entities {
-		if e.Text != "" {
-			filtered = append(filtered, e)
-		}
-	}
-	entities = filtered
+	entities := filterEmptyEntities(state.entities)
 
 	fmt.Printf("[ONNX Model Response] Extracted %d entities from chunk:\n", len(entities))
 	for i, e := range entities {

--- a/src/backend/pii/detectors/onnx_model_detector.go
+++ b/src/backend/pii/detectors/onnx_model_detector.go
@@ -70,14 +70,14 @@ func NewONNXModelDetectorSimple(modelPath string, tokenizerPath string) (*ONNXMo
 	if onnxLibPath == "" {
 		onnxPaths := []string{
 			// macOS paths (.dylib)
-			"./libonnxruntime.1.24.2.dylib",            // CWD (legacy)
-			"./resources/libonnxruntime.1.24.2.dylib",  // Production DMG: CWD is Contents/Resources
-			"./build/libonnxruntime.1.24.2.dylib",      // Development: in build directory
-			"../libonnxruntime.1.24.2.dylib",           // Alternative location
+			"./libonnxruntime.1.24.2.dylib",           // CWD (legacy)
+			"./resources/libonnxruntime.1.24.2.dylib", // Production DMG: CWD is Contents/Resources
+			"./build/libonnxruntime.1.24.2.dylib",     // Development: in build directory
+			"../libonnxruntime.1.24.2.dylib",          // Alternative location
 			// Linux paths (.so)
-			"./lib/libonnxruntime.so.1.24.2",           // Linux release tarball layout
-			"./build/libonnxruntime.so.1.24.2",         // Development: in build directory
-			"./libonnxruntime.so.1.24.2",               // CWD
+			"./lib/libonnxruntime.so.1.24.2",   // Linux release tarball layout
+			"./build/libonnxruntime.so.1.24.2", // Development: in build directory
+			"./libonnxruntime.so.1.24.2",       // CWD
 		}
 
 		for _, p := range onnxPaths {
@@ -391,6 +391,60 @@ func softmaxConfidence(tokenLogits []float32, classIdx int) float64 {
 	return math.Exp(float64(tokenLogits[classIdx])-maxLogit) / sum
 }
 
+func splitBIOLabel(label string) (baseLabel string, isBeginning bool, isInside bool) {
+	isBeginning = strings.HasPrefix(label, "B-")
+	isInside = strings.HasPrefix(label, "I-")
+	if isBeginning || isInside {
+		return strings.TrimPrefix(strings.TrimPrefix(label, "B-"), "I-"), isBeginning, isInside
+	}
+	return label, false, false
+}
+
+func isEntityJoinerToken(tokenText string) bool {
+	trimmed := strings.TrimSpace(tokenText)
+	if trimmed == "" {
+		return false
+	}
+	for _, r := range trimmed {
+		if !strings.ContainsRune(".,@_-+:/#%&=", r) {
+			return false
+		}
+	}
+	return true
+}
+
+func tokenStartsAtPreviousEnd(tokenIndex int, currentTokens []int, offsets []tokenizers.Offset) bool {
+	if len(currentTokens) == 0 || tokenIndex >= len(offsets) {
+		return false
+	}
+	previousTokenIndex := currentTokens[len(currentTokens)-1]
+	if previousTokenIndex >= len(offsets) {
+		return false
+	}
+	return offsets[previousTokenIndex][1] == offsets[tokenIndex][0]
+}
+
+func (d *ONNXModelDetectorSimple) decodedTokenLabel(index int, outputData []float32, bestLabels []int) (string, float64) {
+	startIdx := index * d.numPIILabels
+	endIdx := (index + 1) * d.numPIILabels
+	if startIdx < 0 || endIdx > len(outputData) {
+		return "O", 0
+	}
+
+	tokenLogits := outputData[startIdx:endIdx]
+	if bestLabels != nil && index < len(bestLabels) {
+		classID := bestLabels[index]
+		idStr := fmt.Sprintf("%d", classID)
+		label, ok := d.id2label[idStr]
+		if !ok {
+			label = "O"
+		}
+		return label, softmaxConfidence(tokenLogits, classID)
+	}
+
+	return d.classifyToken(tokenLogits)
+}
+
 // processOutputInline converts model output to entities (inline to avoid compilation issues)
 func (d *ONNXModelDetectorSimple) processOutputInline(originalText string, tokenIDs []uint32, offsets []tokenizers.Offset) []Entity {
 	outputData := d.outputTensor.GetData()
@@ -423,24 +477,9 @@ func (d *ONNXModelDetectorSimple) processOutputInline(originalText string, token
 			fmt.Printf("[ONNX Model Response] Token %d: out of bounds (startIdx=%d, endIdx=%d, outputLen=%d)\n", i, startIdx, endIdx, len(outputData))
 			break // Reached end of output data
 		}
-		tokenLogits := outputData[startIdx:endIdx]
 
 		// Get label and confidence
-		var label string
-		var confidence float64
-		if bestLabels != nil {
-			// Viterbi path — look up label and compute softmax confidence
-			classID := bestLabels[i]
-			idStr := fmt.Sprintf("%d", classID)
-			var ok bool
-			label, ok = d.id2label[idStr]
-			if !ok {
-				label = "O"
-			}
-			confidence = softmaxConfidence(tokenLogits, classID)
-		} else {
-			label, confidence = d.classifyToken(tokenLogits)
-		}
+		label, confidence := d.decodedTokenLabel(i, outputData, bestLabels)
 
 		// Log token details
 		tokenText := ""
@@ -455,16 +494,36 @@ func (d *ONNXModelDetectorSimple) processOutputInline(originalText string, token
 			label = "O"
 		}
 
-		// Handle B-PREFIX (beginning) and I-PREFIX (inside) labels
-		isBeginning := strings.HasPrefix(label, "B-")
-		isInside := strings.HasPrefix(label, "I-")
-		baseLabel := label
-		if isBeginning || isInside {
-			baseLabel = strings.TrimPrefix(strings.TrimPrefix(label, "B-"), "I-")
+		// Punctuation inside compact entities such as emails and URLs may be
+		// decoded as O by older models. If it is sandwiched between tokens of
+		// the same entity label, keep it as a bridge and let finalizeEntity trim
+		// true trailing sentence punctuation.
+		if label == "O" && currentEntity != nil && isEntityJoinerToken(tokenText) {
+			nextLabel, nextConfidence := d.decodedTokenLabel(i+1, outputData, bestLabels)
+			nextBaseLabel, nextIsBeginning, nextIsInside := splitBIOLabel(nextLabel)
+			if nextConfidence >= d.entityConfidenceThreshold &&
+				(nextIsBeginning || nextIsInside) &&
+				nextBaseLabel == currentEntity.Label {
+				label = "I-" + currentEntity.Label
+				confidence = currentEntity.Confidence
+			}
 		}
+
+		// Handle B-PREFIX (beginning) and I-PREFIX (inside) labels
+		baseLabel, isBeginning, isInside := splitBIOLabel(label)
+		isSameCompactEntity := label != "O" &&
+			currentEntity != nil &&
+			currentEntity.Label == baseLabel &&
+			tokenStartsAtPreviousEnd(i, currentTokens, offsets)
 
 		// Handle different entity states using switch for better readability
 		switch {
+		case label != "O" && currentEntity != nil && currentEntity.Label == baseLabel && (isInside || isSameCompactEntity):
+			// Continue current entity. Same-label B tags immediately after a
+			// joiner token are treated as continuation so emails like
+			// "jonathan.reyes@example.com" do not fragment.
+			currentTokens = append(currentTokens, i)
+			currentEntity.Confidence = (currentEntity.Confidence + confidence) / 2
 		case label != "O" && (isBeginning || currentEntity == nil):
 			// Finish previous entity if exists
 			if currentEntity != nil {
@@ -478,11 +537,6 @@ func (d *ONNXModelDetectorSimple) processOutputInline(originalText string, token
 				Confidence: confidence,
 			}
 			currentTokens = []int{i}
-		case label != "O" && isInside && currentEntity != nil && currentEntity.Label == baseLabel:
-			// Continue current entity
-			currentTokens = append(currentTokens, i)
-			// Update confidence to average
-			currentEntity.Confidence = (currentEntity.Confidence + confidence) / 2
 		default:
 			// Finish current entity if exists
 			if currentEntity != nil {

--- a/src/backend/pii/detectors/onnx_model_detector_test.go
+++ b/src/backend/pii/detectors/onnx_model_detector_test.go
@@ -521,6 +521,37 @@ func TestFinalizeEntity_DotInsideEmail(t *testing.T) {
 	}
 }
 
+func TestFinalizeEntity_EmailTrailingSentenceDotTrimmed(t *testing.T) {
+	// Internal email dots should be preserved while the final sentence dot is stripped.
+	detector := &ONNXModelDetectorSimple{}
+	entity := &Entity{Label: "EMAIL", Confidence: 0.90}
+	tokenIndices := []int{0, 1, 2, 3, 4, 5, 6}
+	originalText := "Email jonathan.reyes@example.com."
+	offsets := []tokenizers.Offset{{6, 14}, {14, 15}, {15, 20}, {20, 21}, {21, 28}, {28, 32}, {32, 33}}
+
+	detector.finalizeEntity(entity, tokenIndices, originalText, offsets)
+
+	if entity.Text != "jonathan.reyes@example.com" {
+		t.Errorf("Expected 'jonathan.reyes@example.com', got '%s'", entity.Text)
+	}
+	if entity.EndPos != 32 {
+		t.Errorf("Expected EndPos 32, got %d", entity.EndPos)
+	}
+}
+
+func TestIsEntityJoinerToken(t *testing.T) {
+	for _, token := range []string{".", "@", "-", "_", ":", "/", ".@"} {
+		if !isEntityJoinerToken(token) {
+			t.Errorf("Expected %q to be an entity joiner", token)
+		}
+	}
+	for _, token := range []string{"", " ", "A", "!"} {
+		if isEntityJoinerToken(token) {
+			t.Errorf("Expected %q not to be an entity joiner", token)
+		}
+	}
+}
+
 func TestFinalizeEntity_DotInsideURL(t *testing.T) {
 	// "www.example.com" — dots inside URL should be preserved
 	detector := &ONNXModelDetectorSimple{}

--- a/tests/benchmark/run.py
+++ b/tests/benchmark/run.py
@@ -29,6 +29,8 @@ from model.dataset.huggingface.import_ai4privacy import convert_ai4privacy_sampl
 # ---------------------------------------------------------------------------
 
 DEFAULT_ENTITY_CONFIDENCE_THRESHOLD = 0.25
+MAX_SEQ_LEN = 512
+CHUNK_OVERLAP = 64
 
 
 def viterbi_decode(
@@ -122,6 +124,50 @@ def token_starts_at_previous_end(
     return int(offsets[previous_token_index][1]) == int(offsets[token_index][0])
 
 
+def chunk_ranges(num_tokens: int) -> list[tuple[int, int]]:
+    """Split token indices into backend-equivalent overlapping chunks."""
+    if num_tokens <= MAX_SEQ_LEN:
+        return [(0, num_tokens)]
+
+    ranges = []
+    stride = MAX_SEQ_LEN - CHUNK_OVERLAP
+    if stride <= 0:
+        raise ValueError("CHUNK_OVERLAP must be smaller than MAX_SEQ_LEN")
+
+    for start in range(0, num_tokens, stride):
+        end = min(start + MAX_SEQ_LEN, num_tokens)
+        ranges.append((start, end))
+        if end >= num_tokens:
+            break
+    return ranges
+
+
+def merge_chunk_spans(spans: list[tuple[int, int, str]]) -> list[tuple[int, int, str]]:
+    """Merge duplicate/overlapping entity spans produced by chunk overlap."""
+    if not spans:
+        return []
+
+    merged: list[tuple[int, int, str]] = []
+    for span in sorted(spans, key=lambda x: (x[0], -(x[1] - x[0]), x[2])):
+        if span[0] >= span[1]:
+            continue
+        if not merged or span[0] >= merged[-1][1]:
+            merged.append(span)
+            continue
+
+        last = merged[-1]
+        if span[2] == last[2]:
+            merged[-1] = (last[0], max(last[1], span[1]), last[2])
+            continue
+
+        last_len = last[1] - last[0]
+        span_len = span[1] - span[0]
+        if span_len > last_len:
+            merged[-1] = span
+
+    return merged
+
+
 class OnnxPIIModel:
     """Thin wrapper around the quantized ONNX model for inference."""
 
@@ -169,6 +215,7 @@ class OnnxPIIModel:
             self.transitions = None
             self.start_transitions = None
             self.end_transitions = None
+        self.uses_crf = self.transitions is not None
 
     def _decoded_label(
         self,
@@ -237,22 +284,28 @@ class OnnxPIIModel:
             end -= 1
         return start, end
 
-    def predict(self, text: str) -> list[tuple[int, int, str]]:
-        """Return list of (start, end, label) spans detected in text."""
-        inputs = self.tokenizer(
-            text,
-            return_tensors="np",
-            truncation=True,
-            max_length=512,
-            return_offsets_mapping=True,
-        )
-        offset_mapping = inputs.pop("offset_mapping")[0]
+    def _predict_chunk(
+        self,
+        text: str,
+        input_ids: list[int],
+        offset_mapping: np.ndarray,
+    ) -> list[tuple[int, int, str]]:
+        """Return spans for one token chunk with original-text offsets."""
+        if not input_ids:
+            return []
+
+        num_tokens = len(input_ids)
+        pad_token_id = self.tokenizer.pad_token_id or 0
+        padded_input_ids = input_ids + [pad_token_id] * (MAX_SEQ_LEN - num_tokens)
+        padded_attention_mask = [1] * num_tokens + [0] * (MAX_SEQ_LEN - num_tokens)
+        input_ids_array = np.asarray([padded_input_ids], dtype=np.int64)
+        attention_mask = np.asarray([padded_attention_mask], dtype=np.int64)
         ort_inputs = {
-            "input_ids": inputs["input_ids"],
-            "attention_mask": inputs["attention_mask"],
+            "input_ids": input_ids_array,
+            "attention_mask": attention_mask,
         }
         logits = self.session.run(None, ort_inputs)[0]  # [1, seq, labels]
-        seq_logits = logits[0]  # (seq_len, num_labels)
+        seq_logits = logits[0][:num_tokens]  # (seq_len, num_labels)
 
         if self.transitions is not None:
             # Use Viterbi decoding with CRF transition constraints
@@ -265,7 +318,7 @@ class OnnxPIIModel:
         else:
             predictions = np.argmax(logits, axis=-1)[0]
 
-        tokens = self.tokenizer.convert_ids_to_tokens(inputs["input_ids"][0])
+        tokens = self.tokenizer.convert_ids_to_tokens(input_ids)
         entities: list[tuple[int, int, str]] = []
         cur_label: str | None = None
         cur_start = 0
@@ -289,7 +342,7 @@ class OnnxPIIModel:
                 self.tokenizer.cls_token,
                 self.tokenizer.sep_token,
                 self.tokenizer.pad_token,
-            ):
+            ) or int(offset[1]) <= int(offset[0]):
                 continue
 
             label, confidence = self._decoded_label(index, predictions, seq_logits)
@@ -333,6 +386,27 @@ class OnnxPIIModel:
 
         finish_current()
         return entities
+
+    def predict(self, text: str) -> list[tuple[int, int, str]]:
+        """Return list of (start, end, label) spans detected in text."""
+        inputs = self.tokenizer(
+            text,
+            truncation=False,
+            return_offsets_mapping=True,
+        )
+        input_ids = inputs["input_ids"]
+        offset_mapping = np.asarray(inputs.pop("offset_mapping"), dtype=np.int64)
+
+        entities = []
+        for start, end in chunk_ranges(len(input_ids)):
+            entities.extend(
+                self._predict_chunk(
+                    text,
+                    input_ids[start:end],
+                    offset_mapping[start:end],
+                )
+            )
+        return merge_chunk_spans(entities)
 
 
 # ---------------------------------------------------------------------------
@@ -574,6 +648,7 @@ def main() -> int:
         args.model_path,
         entity_confidence_threshold=args.confidence_threshold,
     )
+    print(f"  CRF decoding: {'enabled' if model.uses_crf else 'disabled'}")
 
     lang_desc = f" (language={args.language})" if args.language else ""
     print(f"Loading {args.num} samples from ai4privacy/pii-masking-300k{lang_desc} ...")
@@ -621,6 +696,9 @@ def main() -> int:
         "language": args.language,
         "model_path": args.model_path,
         "confidence_threshold": args.confidence_threshold,
+        "uses_crf": model.uses_crf,
+        "max_sequence_length": MAX_SEQ_LEN,
+        "chunk_overlap": CHUNK_OVERLAP,
         "exact_span_f1": round(exact_micro_f1, 4),
         "exact_span_macro_f1": round(exact_macro_f1, 4),
         "relaxed_overlap_f1": round(relaxed_micro_f1, 4),

--- a/tests/benchmark/run.py
+++ b/tests/benchmark/run.py
@@ -22,41 +22,14 @@ import onnxruntime as ort
 from datasets import load_dataset
 from transformers import AutoTokenizer
 
-# ---------------------------------------------------------------------------
-# Label mapping: ai4privacy labels -> kiji model labels
-# Only labels that the kiji model supports are mapped; the rest are skipped.
-# ---------------------------------------------------------------------------
-AI4PRIVACY_TO_KIJI: dict[str, str] = {
-    "GIVENNAME1": "FIRSTNAME",
-    "GIVENNAME2": "FIRSTNAME",
-    "LASTNAME1": "SURNAME",
-    "LASTNAME2": "SURNAME",
-    "LASTNAME3": "SURNAME",
-    "EMAIL": "EMAIL",
-    "TEL": "PHONENUMBER",
-    "BOD": "DATEOFBIRTH",
-    "SOCIALNUMBER": "SSN",
-    "STREET": "STREET",
-    "BUILDING": "BUILDINGNUM",
-    "CITY": "CITY",
-    "STATE": "STATE",
-    "POSTCODE": "ZIP",
-    "COUNTRY": "COUNTRY",
-    "DRIVERLICENSE": "DRIVERLICENSENUM",
-    "PASSPORT": "PASSPORTID",
-    "IDCARD": "NATIONALID",
-    "USERNAME": "USERNAME",
-    "PASS": "PASSWORD",
-}
-
-# Labels in the ai4privacy dataset that we intentionally skip because the
-# kiji model has no equivalent: TIME, DATE, TITLE, SEX, GEOCOORD, IP,
-# CARDISSUER, SECADDRESS
-
+from model.dataset.huggingface.import_ai4privacy import convert_ai4privacy_sample
 
 # ---------------------------------------------------------------------------
 # ONNX model wrapper
 # ---------------------------------------------------------------------------
+
+DEFAULT_ENTITY_CONFIDENCE_THRESHOLD = 0.25
+
 
 def viterbi_decode(
     logits: np.ndarray,
@@ -104,10 +77,59 @@ def viterbi_decode(
     return best_path
 
 
+def softmax_confidence(token_logits: np.ndarray, class_idx: int) -> float:
+    """Return the softmax confidence for one decoded class."""
+    max_logit = float(np.max(token_logits))
+    exp_scores = np.exp(token_logits - max_logit)
+    return float(exp_scores[class_idx] / np.sum(exp_scores))
+
+
+def split_bio_label(label: str) -> tuple[str, bool, bool]:
+    """Split a BIO label into base label and B/I flags."""
+    is_beginning = label.startswith("B-")
+    is_inside = label.startswith("I-")
+    if is_beginning or is_inside:
+        return label[2:], is_beginning, is_inside
+    return label, False, False
+
+
+def is_entity_joiner_token(token_text: str) -> bool:
+    """Mirror backend compact-entity joiner detection."""
+    trimmed = token_text.strip()
+    return bool(trimmed) and all(c in ".,@_-+:/#%&=" for c in trimmed)
+
+
+def token_text_at(text: str, offset: np.ndarray) -> str:
+    """Return token text from an offset mapping, with bounds checks."""
+    start = int(offset[0])
+    end = int(offset[1])
+    if start < 0 or end > len(text) or end <= start:
+        return ""
+    return text[start:end]
+
+
+def token_starts_at_previous_end(
+    token_index: int,
+    current_tokens: list[int],
+    offsets: np.ndarray,
+) -> bool:
+    """Check whether the current token is contiguous with the current entity."""
+    if not current_tokens or token_index >= len(offsets):
+        return False
+    previous_token_index = current_tokens[-1]
+    if previous_token_index >= len(offsets):
+        return False
+    return int(offsets[previous_token_index][1]) == int(offsets[token_index][0])
+
+
 class OnnxPIIModel:
     """Thin wrapper around the quantized ONNX model for inference."""
 
-    def __init__(self, model_dir: str):
+    def __init__(
+        self,
+        model_dir: str,
+        entity_confidence_threshold: float = DEFAULT_ENTITY_CONFIDENCE_THRESHOLD,
+    ):
         model_dir = Path(model_dir)
         onnx_file = model_dir / "model_quantized.onnx"
         if not onnx_file.exists():
@@ -121,6 +143,7 @@ class OnnxPIIModel:
         self.id2label: dict[int, str] = {
             int(k): v for k, v in mappings["pii"]["id2label"].items()
         }
+        self.entity_confidence_threshold = entity_confidence_threshold
 
         self.tokenizer = AutoTokenizer.from_pretrained(str(model_dir))
 
@@ -138,12 +161,60 @@ class OnnxPIIModel:
             with crf_path.open() as f:
                 crf = json.load(f)
             self.transitions = np.array(crf["transitions"], dtype=np.float32)
-            self.start_transitions = np.array(crf["start_transitions"], dtype=np.float32)
+            self.start_transitions = np.array(
+                crf["start_transitions"], dtype=np.float32
+            )
             self.end_transitions = np.array(crf["end_transitions"], dtype=np.float32)
         else:
             self.transitions = None
             self.start_transitions = None
             self.end_transitions = None
+
+    def _decoded_label(
+        self,
+        index: int,
+        predictions: list[int] | np.ndarray,
+        logits: np.ndarray,
+    ) -> tuple[str, float]:
+        """Return decoded label and softmax confidence for one token."""
+        if index >= len(predictions):
+            return "O", 0.0
+        class_id = int(predictions[index])
+        if class_id < 0 or class_id >= logits.shape[-1]:
+            return "O", 0.0
+        label = self.id2label.get(class_id, "O")
+        return label, softmax_confidence(logits[index], class_id)
+
+    def _bridge_joiner_token(
+        self,
+        index: int,
+        token_text: str,
+        label: str,
+        confidence: float,
+        predictions: list[int] | np.ndarray,
+        logits: np.ndarray,
+        current_label: str | None,
+    ) -> tuple[str, float]:
+        """Mirror backend joiner bridging for compact entities like emails."""
+        if (
+            label != "O"
+            or current_label is None
+            or not is_entity_joiner_token(token_text)
+        ):
+            return label, confidence
+
+        next_label, next_confidence = self._decoded_label(
+            index + 1, predictions, logits
+        )
+        next_base_label, next_is_beginning, next_is_inside = split_bio_label(next_label)
+        if (
+            next_confidence >= self.entity_confidence_threshold
+            and (next_is_beginning or next_is_inside)
+            and next_base_label == current_label
+        ):
+            return f"I-{current_label}", confidence
+
+        return label, confidence
 
     def _trim_span(self, text: str, start: int, end: int) -> tuple[int, int]:
         """Trim leading/trailing whitespace and trailing punctuation from a span.
@@ -181,10 +252,10 @@ class OnnxPIIModel:
             "attention_mask": inputs["attention_mask"],
         }
         logits = self.session.run(None, ort_inputs)[0]  # [1, seq, labels]
+        seq_logits = logits[0]  # (seq_len, num_labels)
 
         if self.transitions is not None:
             # Use Viterbi decoding with CRF transition constraints
-            seq_logits = logits[0]  # (seq_len, num_labels)
             predictions = viterbi_decode(
                 seq_logits,
                 self.transitions,
@@ -199,39 +270,68 @@ class OnnxPIIModel:
         cur_label: str | None = None
         cur_start = 0
         cur_end = 0
+        cur_tokens: list[int] = []
 
-        for token, pred, offset in zip(tokens, predictions, offset_mapping, strict=True):
+        def finish_current() -> None:
+            nonlocal cur_label, cur_start, cur_end, cur_tokens
+            if cur_label is None:
+                return
+            s, e = self._trim_span(text, cur_start, cur_end)
+            if s < e:
+                entities.append((s, e, cur_label))
+            cur_label = None
+            cur_tokens = []
+
+        for index, (token, offset) in enumerate(
+            zip(tokens, offset_mapping, strict=True)
+        ):
             if token in (
                 self.tokenizer.cls_token,
                 self.tokenizer.sep_token,
                 self.tokenizer.pad_token,
             ):
                 continue
-            label = self.id2label.get(int(pred), "O")
-            if label.startswith("B-"):
-                if cur_label is not None:
-                    s, e = self._trim_span(text, cur_start, cur_end)
-                    if s < e:
-                        entities.append((s, e, cur_label))
-                cur_label = label[2:]
-                cur_start = int(offset[0])
-                cur_end = int(offset[1])
-            elif (
-                label.startswith("I-")
+
+            label, confidence = self._decoded_label(index, predictions, seq_logits)
+            token_text = token_text_at(text, offset)
+            if confidence < self.entity_confidence_threshold:
+                label = "O"
+            label, confidence = self._bridge_joiner_token(
+                index,
+                token_text,
+                label,
+                confidence,
+                predictions,
+                seq_logits,
+                cur_label,
+            )
+
+            base_label, is_beginning, is_inside = split_bio_label(label)
+            is_same_compact_entity = (
+                label != "O"
                 and cur_label is not None
-                and cur_label == label[2:]
+                and cur_label == base_label
+                and token_starts_at_previous_end(index, cur_tokens, offset_mapping)
+            )
+
+            if (
+                label != "O"
+                and cur_label is not None
+                and cur_label == base_label
+                and (is_inside or is_same_compact_entity)
             ):
                 cur_end = int(offset[1])
+                cur_tokens.append(index)
+            elif label != "O" and (is_beginning or cur_label is None):
+                finish_current()
+                cur_label = base_label
+                cur_start = int(offset[0])
+                cur_end = int(offset[1])
+                cur_tokens = [index]
             else:
-                if cur_label is not None:
-                    s, e = self._trim_span(text, cur_start, cur_end)
-                    if s < e:
-                        entities.append((s, e, cur_label))
-                    cur_label = None
-        if cur_label is not None:
-            s, e = self._trim_span(text, cur_start, cur_end)
-            if s < e:
-                entities.append((s, e, cur_label))
+                finish_current()
+
+        finish_current()
         return entities
 
 
@@ -267,7 +367,9 @@ class SpanMetrics:
             rec = tp / (tp + fn) if (tp + fn) else 0.0
             f1 = 2 * prec * rec / (prec + rec) if (prec + rec) else 0.0
             out[label] = {
-                "tp": tp, "fp": fp, "fn": fn,
+                "tp": tp,
+                "fp": fp,
+                "fn": fn,
                 "precision": round(prec, 4),
                 "recall": round(rec, 4),
                 "f1": round(f1, 4),
@@ -289,9 +391,46 @@ class SpanMetrics:
         return sum(m["f1"] for m in per.values()) / len(per)
 
 
+class RelaxedOverlapMetrics(SpanMetrics):
+    """Same-label one-to-one span-overlap scoring."""
+
+    @staticmethod
+    def _overlap_len(left: Span, right: Span) -> int:
+        return max(0, min(left[1], right[1]) - max(left[0], right[0]))
+
+    def update(self, gold: list[Span], predicted: list[Span]) -> None:
+        gold_spans = sorted(set(gold))
+        pred_spans = sorted(set(predicted))
+        candidates: list[tuple[int, int, int]] = []
+        for gold_idx, gold_span in enumerate(gold_spans):
+            for pred_idx, pred_span in enumerate(pred_spans):
+                if gold_span[2] != pred_span[2]:
+                    continue
+                overlap_len = self._overlap_len(gold_span, pred_span)
+                if overlap_len > 0:
+                    candidates.append((overlap_len, gold_idx, pred_idx))
+
+        matched_gold: set[int] = set()
+        matched_pred: set[int] = set()
+        for _overlap_len, gold_idx, pred_idx in sorted(candidates, reverse=True):
+            if gold_idx in matched_gold or pred_idx in matched_pred:
+                continue
+            matched_gold.add(gold_idx)
+            matched_pred.add(pred_idx)
+            self.tp[gold_spans[gold_idx][2]] += 1
+
+        for idx, span in enumerate(gold_spans):
+            if idx not in matched_gold:
+                self.fn[span[2]] += 1
+        for idx, span in enumerate(pred_spans):
+            if idx not in matched_pred:
+                self.fp[span[2]] += 1
+
+
 # ---------------------------------------------------------------------------
 # Dataset loading and conversion
 # ---------------------------------------------------------------------------
+
 
 def load_ai4privacy_samples(
     num: int,
@@ -309,24 +448,30 @@ def load_ai4privacy_samples(
         split="train",
         streaming=True,
     )
+    if language is not None:
+        normalized_language = language.lower()
+        ds = ds.filter(
+            lambda row: row.get("language", "").lower() == normalized_language
+        )
     ds = ds.shuffle(seed=seed, buffer_size=1000)
 
     samples: list[dict] = []
     for row in ds:
-        if language is not None and row.get("language", "").lower() != language.lower():
+        sample = convert_ai4privacy_sample(row)
+        if sample is None:
             continue
+
         entities: list[Span] = []
-        for ent in row["privacy_mask"]:
-            kiji_label = AI4PRIVACY_TO_KIJI.get(ent["label"])
-            if kiji_label is None:
-                continue
-            entities.append((ent["start"], ent["end"], kiji_label))
+        for ent in sample["privacy_mask"]:
+            entities.append((ent["start"], ent["end"], ent["label"]))
         if not entities:
             continue
-        samples.append({
-            "text": row["source_text"],
-            "entities": entities,
-        })
+        samples.append(
+            {
+                "text": sample["text"],
+                "entities": entities,
+            }
+        )
         if len(samples) >= num:
             break
     return samples
@@ -336,6 +481,7 @@ def load_ai4privacy_samples(
 # Verbose per-sample output
 # ---------------------------------------------------------------------------
 
+
 def print_sample_detections(
     index: int,
     text: str,
@@ -344,10 +490,10 @@ def print_sample_detections(
     elapsed_ms: float,
 ) -> None:
     """Print gold vs predicted entities for a single sample."""
-    print(f"\n{'─'*70}")
+    print(f"\n{'─' * 70}")
     print(f"Sample {index + 1}  ({elapsed_ms:.1f} ms)")
-    print(f"{'─'*70}")
-    print(f"  Text:")
+    print(f"{'─' * 70}")
+    print("  Text:")
     for line in text.splitlines():
         print(f"    {line}")
 
@@ -355,8 +501,6 @@ def print_sample_detections(
     pred_set = set(predicted)
 
     tp = gold_set & pred_set
-    fn = gold_set - pred_set
-    fp = pred_set - gold_set
 
     print(f"  Expected ({len(gold_set)}):")
     if gold_set:
@@ -364,43 +508,56 @@ def print_sample_detections(
             marker = "TP" if (start, end, label) in tp else "FN"
             print(f"    [{label:<20s}] {text[start:end]!r}  ({marker})")
     else:
-        print(f"    (none)")
+        print("    (none)")
     print(f"  Predicted ({len(pred_set)}):")
     if pred_set:
         for start, end, label in sorted(pred_set):
             marker = "TP" if (start, end, label) in tp else "FP"
             print(f"    [{label:<20s}] {text[start:end]!r}  ({marker})")
     else:
-        print(f"    (none)")
+        print("    (none)")
 
 
 # ---------------------------------------------------------------------------
 # Main
 # ---------------------------------------------------------------------------
 
+
 def parse_args() -> argparse.Namespace:
     ap = argparse.ArgumentParser(
         description="Benchmark kiji PII model against ai4privacy/pii-masking-300k"
     )
     ap.add_argument(
-        "--num", type=int, default=1000,
+        "--num",
+        type=int,
+        default=1000,
         help="Number of samples to evaluate (default: 1000).",
     )
     ap.add_argument(
-        "--model-path", default="./model/quantized",
+        "--model-path",
+        default="./model/quantized",
         help="Path to the quantized ONNX model directory.",
     )
     ap.add_argument(
-        "--report", default=str(Path(__file__).parent / "reports" / "latest.json"),
+        "--report",
+        default=str(Path(__file__).parent / "reports" / "latest.json"),
         help="Path to write the JSON report.",
     )
     ap.add_argument("--seed", type=int, default=42)
     ap.add_argument(
-        "--language", default=None,
+        "--confidence-threshold",
+        type=float,
+        default=DEFAULT_ENTITY_CONFIDENCE_THRESHOLD,
+        help="Minimum token confidence before treating a label as O. Mirrors backend default.",
+    )
+    ap.add_argument(
+        "--language",
+        default=None,
         help="Filter samples by language (e.g. 'English', 'German'). Default: all languages.",
     )
     ap.add_argument(
-        "--verbose", action="store_true",
+        "--verbose",
+        action="store_true",
         help="Print per-sample detections (only allowed when --num < 50).",
     )
     args = ap.parse_args()
@@ -413,7 +570,10 @@ def main() -> int:
     args = parse_args()
 
     print(f"Loading ONNX model from {args.model_path} ...")
-    model = OnnxPIIModel(args.model_path)
+    model = OnnxPIIModel(
+        args.model_path,
+        entity_confidence_threshold=args.confidence_threshold,
+    )
 
     lang_desc = f" (language={args.language})" if args.language else ""
     print(f"Loading {args.num} samples from ai4privacy/pii-masking-300k{lang_desc} ...")
@@ -424,7 +584,8 @@ def main() -> int:
         print("No samples loaded.", file=sys.stderr)
         return 1
 
-    metrics = SpanMetrics()
+    exact_metrics = SpanMetrics()
+    relaxed_metrics = RelaxedOverlapMetrics()
     latencies: list[float] = []
 
     for i, sample in enumerate(samples):
@@ -432,31 +593,57 @@ def main() -> int:
         predicted = model.predict(sample["text"])
         elapsed_ms = (time.perf_counter() - t0) * 1000
         latencies.append(elapsed_ms)
-        metrics.update(sample["entities"], predicted)
+        exact_metrics.update(sample["entities"], predicted)
+        relaxed_metrics.update(sample["entities"], predicted)
         if args.verbose:
             print_sample_detections(
-                i, sample["text"], sample["entities"], predicted, elapsed_ms,
+                i,
+                sample["text"],
+                sample["entities"],
+                predicted,
+                elapsed_ms,
             )
         elif (i + 1) % 200 == 0:
             print(f"  Processed {i + 1}/{len(samples)} ...")
 
     # Build report
     lat_arr = np.asarray(latencies, dtype=float)
-    per_label = metrics.per_label()
+    exact_per_label = exact_metrics.per_label()
+    relaxed_per_label = relaxed_metrics.per_label()
+    exact_micro_f1 = exact_metrics.micro_f1()
+    exact_macro_f1 = exact_metrics.macro_f1()
+    relaxed_micro_f1 = relaxed_metrics.micro_f1()
+    relaxed_macro_f1 = relaxed_metrics.macro_f1()
     report = {
         "dataset": "ai4privacy/pii-masking-300k",
         "num_samples": len(samples),
         "seed": args.seed,
+        "language": args.language,
         "model_path": args.model_path,
-        "micro_f1": round(metrics.micro_f1(), 4),
-        "macro_f1": round(metrics.macro_f1(), 4),
+        "confidence_threshold": args.confidence_threshold,
+        "exact_span_f1": round(exact_micro_f1, 4),
+        "exact_span_macro_f1": round(exact_macro_f1, 4),
+        "relaxed_overlap_f1": round(relaxed_micro_f1, 4),
+        "relaxed_overlap_macro_f1": round(relaxed_macro_f1, 4),
+        "micro_f1": round(exact_micro_f1, 4),
+        "macro_f1": round(exact_macro_f1, 4),
         "latency_ms": {
             "p50": float(round(np.percentile(lat_arr, 50), 2)),
             "p95": float(round(np.percentile(lat_arr, 95), 2)),
             "p99": float(round(np.percentile(lat_arr, 99), 2)),
             "mean": float(round(np.mean(lat_arr), 2)),
         },
-        "per_label": per_label,
+        "per_label": exact_per_label,
+        "exact_span": {
+            "micro_f1": round(exact_micro_f1, 4),
+            "macro_f1": round(exact_macro_f1, 4),
+            "per_label": exact_per_label,
+        },
+        "relaxed_same_label_overlap": {
+            "micro_f1": round(relaxed_micro_f1, 4),
+            "macro_f1": round(relaxed_macro_f1, 4),
+            "per_label": relaxed_per_label,
+        },
     }
 
     report_path = Path(args.report)
@@ -465,18 +652,34 @@ def main() -> int:
         json.dump(report, f, indent=2)
 
     # Print summary
-    print(f"\n{'='*60}")
+    print(f"\n{'=' * 60}")
     print(f"Benchmark Results  ({len(samples)} samples)")
-    print(f"{'='*60}")
-    print(f"  micro-F1 : {report['micro_f1']}")
-    print(f"  macro-F1 : {report['macro_f1']}")
+    print(f"{'=' * 60}")
+    print(f"  exact span micro-F1          : {report['exact_span_f1']}")
+    print(f"  exact span macro-F1          : {report['exact_span_macro_f1']}")
+    print(f"  relaxed overlap micro-F1    : {report['relaxed_overlap_f1']}")
+    print(f"  relaxed overlap macro-F1    : {report['relaxed_overlap_macro_f1']}")
     print(f"  latency p50: {report['latency_ms']['p50']} ms")
     print(f"  latency p95: {report['latency_ms']['p95']} ms")
     print(f"  latency p99: {report['latency_ms']['p99']} ms")
-    print(f"\nPer-label breakdown:")
-    print(f"  {'Label':<22s} {'Prec':>6s} {'Rec':>6s} {'F1':>6s}  {'TP':>5s} {'FP':>5s} {'FN':>5s}")
-    print(f"  {'-'*62}")
-    for label, m in sorted(per_label.items()):
+
+    print("\nExact span per-label breakdown:")
+    print(
+        f"  {'Label':<22s} {'Prec':>6s} {'Rec':>6s} {'F1':>6s}  {'TP':>5s} {'FP':>5s} {'FN':>5s}"
+    )
+    print(f"  {'-' * 62}")
+    for label, m in sorted(exact_per_label.items()):
+        print(
+            f"  {label:<22s} {m['precision']:6.3f} {m['recall']:6.3f} {m['f1']:6.3f}"
+            f"  {m['tp']:5d} {m['fp']:5d} {m['fn']:5d}"
+        )
+
+    print("\nRelaxed same-label overlap per-label breakdown:")
+    print(
+        f"  {'Label':<22s} {'Prec':>6s} {'Rec':>6s} {'F1':>6s}  {'TP':>5s} {'FP':>5s} {'FN':>5s}"
+    )
+    print(f"  {'-' * 62}")
+    for label, m in sorted(relaxed_per_label.items()):
         print(
             f"  {label:<22s} {m['precision']:6.3f} {m['recall']:6.3f} {m['f1']:6.3f}"
             f"  {m['tp']:5d} {m['fp']:5d} {m['fn']:5d}"

--- a/tests/benchmark/smoke_test.py
+++ b/tests/benchmark/smoke_test.py
@@ -13,22 +13,36 @@ import os
 import sys
 from pathlib import Path
 
-import numpy as np
-import onnxruntime as ort
-from transformers import AutoTokenizer
+from tests.benchmark.run import (
+    DEFAULT_ENTITY_CONFIDENCE_THRESHOLD,
+    OnnxPIIModel,
+)
 
 TESTS = [
     (
         "My name is John Smith and my email is john.smith@email.com.",
-        {"FIRSTNAME": ["John"], "SURNAME": ["Smith"], "EMAIL": ["john.smith@email.com"]},
+        {
+            "FIRSTNAME": ["John"],
+            "SURNAME": ["Smith"],
+            "EMAIL": ["john.smith@email.com"],
+        },
     ),
     (
         "Call Sarah Johnson at 555-123-4567. She was born on March 15, 1985.",
-        {"FIRSTNAME": ["Sarah"], "SURNAME": ["Johnson"], "PHONENUMBER": ["555-123-4567"]},
+        {
+            "FIRSTNAME": ["Sarah"],
+            "SURNAME": ["Johnson"],
+            "PHONENUMBER": ["555-123-4567"],
+        },
     ),
     (
         "I live at 123 Main Street, Springfield, IL 62701.",
-        {"STREET": ["Main Street"], "CITY": ["Springfield"], "STATE": ["IL"], "ZIP": ["62701"]},
+        {
+            "STREET": ["Main Street"],
+            "CITY": ["Springfield"],
+            "STATE": ["IL"],
+            "ZIP": ["62701"],
+        },
     ),
 ]
 
@@ -36,6 +50,12 @@ TESTS = [
 def main() -> int:
     ap = argparse.ArgumentParser()
     ap.add_argument("--model-path", default="./model/quantized")
+    ap.add_argument(
+        "--confidence-threshold",
+        type=float,
+        default=DEFAULT_ENTITY_CONFIDENCE_THRESHOLD,
+        help="Minimum token confidence before treating a label as O.",
+    )
     args = ap.parse_args()
 
     model_dir = Path(args.model_path)
@@ -50,6 +70,7 @@ def main() -> int:
     print(f"ONNX size:       {size_mb:.1f} MB")
     mod_time = os.path.getmtime(onnx_file)
     from datetime import datetime
+
     print(f"Last modified:   {datetime.fromtimestamp(mod_time)}")
 
     # Hash full file to fingerprint the model
@@ -59,53 +80,42 @@ def main() -> int:
             h.update(chunk)
     print(f"SHA256:          {h.hexdigest()[:16]}...")
 
-    # Load model
     import json
+
     with (model_dir / "label_mappings.json").open() as f:
         mappings = json.load(f)
     id2label = {int(k): v for k, v in mappings["pii"]["id2label"].items()}
     print(f"Labels:          {len(id2label)}")
 
-    tokenizer = AutoTokenizer.from_pretrained(str(model_dir))
-    session = ort.InferenceSession(
-        str(onnx_file),
-        providers=["CPUExecutionProvider"],
+    model = OnnxPIIModel(
+        str(model_dir),
+        entity_confidence_threshold=args.confidence_threshold,
     )
+    print(f"CRF decoding:    {'enabled' if model.uses_crf else 'disabled'}")
 
-    print(f"\n{'='*60}")
+    print(f"\n{'=' * 60}")
     passed = 0
     failed = 0
 
     for text, expected in TESTS:
-        inputs = tokenizer(text, return_tensors="np", truncation=True, max_length=512)
-        ort_inputs = {
-            "input_ids": inputs["input_ids"],
-            "attention_mask": inputs["attention_mask"],
-        }
-        logits = session.run(None, ort_inputs)[0]
-        preds = np.argmax(logits, axis=-1)[0]
-
-        # Collect predicted labels (ignore O and special tokens)
-        detected_labels = set()
-        for p in preds:
-            label = id2label.get(int(p), "O")
-            if label not in ("O", "IGNORE"):
-                base = label[2:] if label.startswith(("B-", "I-")) else label
-                detected_labels.add(base)
+        spans = model.predict(text)
+        detected_labels = {label for _, _, label in spans}
 
         print(f"\nText: {text[:70]}...")
         print(f"  Expected labels: {sorted(expected.keys())}")
         print(f"  Detected labels: {sorted(detected_labels)}")
+        for start, end, label in spans:
+            print(f"    [{label:<20s}] {text[start:end]!r}")
 
         missing = set(expected.keys()) - detected_labels
         if missing:
             print(f"  FAIL - missing: {sorted(missing)}")
             failed += 1
         else:
-            print(f"  PASS")
+            print("  PASS")
             passed += 1
 
-    print(f"\n{'='*60}")
+    print(f"\n{'=' * 60}")
     print(f"Results: {passed} passed, {failed} failed out of {len(TESTS)}")
     return 1 if failed else 0
 

--- a/tests/test_tokenization.py
+++ b/tests/test_tokenization.py
@@ -1,0 +1,155 @@
+from __future__ import annotations
+
+from model.dataset.label_utils import LabelUtils
+from model.dataset.tokenization import TokenizationProcessor
+
+
+class FakeTokenizer:
+    def __init__(self, tokens: list[str], offsets: list[tuple[int, int]]):
+        self.tokens = tokens
+        self.offsets = offsets
+        self.token_to_id = {token: idx for idx, token in enumerate(tokens)}
+
+    def __call__(self, _text: str, **_kwargs):
+        return {
+            "input_ids": list(range(len(self.tokens))),
+            "attention_mask": [1] * len(self.tokens),
+            "offset_mapping": self.offsets,
+        }
+
+    def convert_ids_to_tokens(self, token_ids: list[int]) -> list[str]:
+        return [self.tokens[token_id] for token_id in token_ids]
+
+    def convert_tokens_to_string(self, tokens: list[str]) -> str:
+        return "".join(tokens).lstrip("▁")
+
+
+def _processor(tokens: list[str], offsets: list[tuple[int, int]]):
+    label2id, id2label = LabelUtils.create_standard_label2id()
+    return TokenizationProcessor(FakeTokenizer(tokens, offsets), label2id, id2label)
+
+
+def _label_names(sample: dict) -> list[str]:
+    _label2id, id2label = LabelUtils.create_standard_label2id()
+    return [id2label.get(label_id, "O") for label_id in sample["labels"]]
+
+
+def test_embedded_email_in_markup_is_labeled():
+    text = "<Email>jankulovska18@aol.com</Email>"
+    value = "jankulovska18@aol.com"
+    tokens = [
+        "[CLS]",
+        "▁<",
+        "Email",
+        ">",
+        "jan",
+        "kul",
+        "ovska",
+        "18",
+        "@",
+        "aol",
+        ".",
+        "com",
+        "<",
+        "/",
+        "Email",
+        ">",
+        "[SEP]",
+    ]
+    offsets = [
+        (0, 0),
+        (0, 1),
+        (1, 6),
+        (6, 7),
+        (7, 10),
+        (10, 13),
+        (13, 18),
+        (18, 20),
+        (20, 21),
+        (21, 24),
+        (24, 25),
+        (25, 28),
+        (28, 29),
+        (29, 30),
+        (30, 35),
+        (35, 36),
+        (0, 0),
+    ]
+    start = text.index(value)
+    sample = _processor(tokens, offsets).create_pii_sample(
+        text,
+        [{"value": value, "label": "EMAIL", "start": start, "end": start + len(value)}],
+    )
+
+    assert _label_names(sample) == [
+        "IGNORE",
+        "O",
+        "O",
+        "O",
+        "B-EMAIL",
+        "I-EMAIL",
+        "I-EMAIL",
+        "I-EMAIL",
+        "I-EMAIL",
+        "I-EMAIL",
+        "I-EMAIL",
+        "I-EMAIL",
+        "O",
+        "O",
+        "O",
+        "O",
+        "IGNORE",
+    ]
+
+
+def test_trailing_email_period_is_not_labeled():
+    text = "Email jonathan.reyes@example.com."
+    value = "jonathan.reyes@example.com"
+    tokens = [
+        "[CLS]",
+        "▁Email",
+        "▁jonathan",
+        ".",
+        "re",
+        "yes",
+        "@",
+        "example",
+        ".",
+        "com",
+        ".",
+        "[SEP]",
+    ]
+    offsets = [
+        (0, 0),
+        (0, 5),
+        (6, 14),
+        (14, 15),
+        (15, 17),
+        (17, 20),
+        (20, 21),
+        (21, 28),
+        (28, 29),
+        (29, 32),
+        (32, 33),
+        (0, 0),
+    ]
+    start = text.index(value)
+    sample = _processor(tokens, offsets).create_pii_sample(
+        text,
+        [{"value": value, "label": "EMAIL", "start": start, "end": start + len(value)}],
+    )
+
+    assert _label_names(sample) == [
+        "IGNORE",
+        "O",
+        "B-EMAIL",
+        "I-EMAIL",
+        "I-EMAIL",
+        "I-EMAIL",
+        "I-EMAIL",
+        "I-EMAIL",
+        "I-EMAIL",
+        "I-EMAIL",
+        "O",
+        "IGNORE",
+    ]


### PR DESCRIPTION
## Summary
- Correct the Chrome extension popup stats so `Messages checked` increments once per completed check and `PII masked` tracks masked entities instead of reusing the old boolean-style counter.
- Update the extension flow to record masked entity counts only when the user applies the masked version, and clean up the popup/storage wiring.
- Refresh the extension docs and privacy policy wording to match the new stats semantics.
- Include updated model pipeline, quantized artifacts, detector, and benchmark changes already bundled on this branch.

## Testing
- Not run (not requested)
- Validated the touched extension scripts with syntax checks and diff consistency during implementation.