### PR TITLE
fix: extension PII masked counter

### DIFF
--- a/chrome-extension/PRIVACY_POLICY.md
+++ b/chrome-extension/PRIVACY_POLICY.md
@@ -15,7 +15,7 @@ The Kiji Privacy Proxy Extension checks text you type into AI chat services (suc
 ### What data is stored locally
 
 - **Settings:** your backend server URL and the list of monitored domains (stored in `chrome.storage.sync`).
-- **Session statistics:** the number of messages checked and the number containing PII (stored in `chrome.storage.local`). These counters reset when the extension is reinstalled.
+- **Session statistics:** the number of messages checked and the number of PII entities masked after you choose the masked version (stored in `chrome.storage.local`). These counters reset when the extension is reinstalled.
 
 ### What data is transmitted
 
@@ -55,4 +55,3 @@ Updates to this policy will be posted in the extension's GitHub repository. The 
 ## Contact
 
 For questions about this privacy policy or the extension's data practices, please open an issue at: https://github.com/dataiku/kiji-proxy/issues
-

--- a/chrome-extension/background.js
+++ b/chrome-extension/background.js
@@ -153,7 +153,12 @@ function scheduleNextCheck() {
 // --- Lifecycle ---
 
 chrome.runtime.onInstalled.addListener(() => {
-  chrome.storage.local.set({ checksTotal: 0, piiFound: 0, connected: false });
+  chrome.storage.local.set({
+    checksTotal: 0,
+    piiMasked: 0,
+    connected: false,
+  });
+  chrome.storage.local.remove("piiFound");
   loadSettingsAndCheck();
   loadDomainsAndRegister();
 });
@@ -213,12 +218,8 @@ async function handlePIICheck(text) {
     return { success: false, error, url };
   }
 
-  chrome.storage.local.get({ checksTotal: 0, piiFound: 0 }, (result) => {
-    const updates = { checksTotal: result.checksTotal + 1 };
-    if (data.pii_found) {
-      updates.piiFound = result.piiFound + 1;
-    }
-    chrome.storage.local.set(updates);
+  chrome.storage.local.get({ checksTotal: 0 }, (result) => {
+    chrome.storage.local.set({ checksTotal: result.checksTotal + 1 });
   });
 
   return { success: true, data };
@@ -230,24 +231,23 @@ chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
     return true; // keep channel open for async sendResponse
   }
 
-  if (message.type === "pii-check") {
-    chrome.storage.local.get({ checksTotal: 0, piiFound: 0 }, (result) => {
-      const updates = { checksTotal: result.checksTotal + 1 };
-      if (message.found) {
-        updates.piiFound = result.piiFound + 1;
-      }
-      chrome.storage.local.set(updates);
+  if (message.type === "pii-masked") {
+    const count = Number.isFinite(message.count)
+      ? Math.max(0, Math.floor(message.count))
+      : 0;
+    chrome.storage.local.get({ piiMasked: 0 }, (result) => {
+      chrome.storage.local.set({ piiMasked: result.piiMasked + count });
     });
   }
 
   if (message.type === "get-status") {
     chrome.storage.local.get(
-      { connected: false, checksTotal: 0, piiFound: 0 },
+      { connected: false, checksTotal: 0, piiMasked: 0 },
       (result) => {
         sendResponse({
           connected: result.connected,
           checksTotal: result.checksTotal,
-          piiFound: result.piiFound,
+          piiMasked: result.piiMasked,
           backendUrl: backendUrl,
         });
       }
@@ -258,12 +258,12 @@ chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
   if (message.type === "refresh-status") {
     checkHealth().then(() => {
       chrome.storage.local.get(
-        { connected: false, checksTotal: 0, piiFound: 0 },
+        { connected: false, checksTotal: 0, piiMasked: 0 },
         (result) => {
           sendResponse({
             connected: result.connected,
             checksTotal: result.checksTotal,
-            piiFound: result.piiFound,
+            piiMasked: result.piiMasked,
             backendUrl: backendUrl,
           });
         }

--- a/chrome-extension/content.js
+++ b/chrome-extension/content.js
@@ -289,6 +289,16 @@
   let lastCheckError = null;
   let contextInvalidated = false;
 
+  function countMaskedEntities(result) {
+    if (Array.isArray(result?.detected_entities)) {
+      return result.detected_entities.length;
+    }
+    if (result?.entities && typeof result.entities === "object") {
+      return Object.keys(result.entities).length;
+    }
+    return result?.pii_found ? 1 : 0;
+  }
+
   function isExtensionAlive() {
     try {
       return !!(chrome.runtime && chrome.runtime.id);
@@ -403,18 +413,6 @@
         return;
       }
 
-      // Notify background service worker of the check result
-      if (isExtensionAlive()) {
-        try {
-          chrome.runtime.sendMessage({
-            type: "pii-check",
-            found: result.pii_found,
-          });
-        } catch (e) {
-          // Background may not be available
-        }
-      }
-
       if (result.pii_found) {
         console.log("Kiji Privacy Proxy Extension: PII detected");
         showPIIModal(result, text, (action, maskedText) => {
@@ -425,6 +423,16 @@
             case "use-masked":
               setInputText(maskedText);
               maskedTextPending = maskedText;
+              if (isExtensionAlive()) {
+                try {
+                  chrome.runtime.sendMessage({
+                    type: "pii-masked",
+                    count: countMaskedEntities(result),
+                  });
+                } catch (e) {
+                  // Background may not be available
+                }
+              }
               // Don't auto-submit, let user review the masked text first
               break;
             case "send-anyway":

--- a/chrome-extension/popup.html
+++ b/chrome-extension/popup.html
@@ -40,7 +40,7 @@
           <span class="stat-label">Messages checked</span>
         </div>
         <div class="stat stat-accent">
-          <span class="stat-value" id="pii-found">0</span>
+          <span class="stat-value" id="pii-masked">0</span>
           <span class="stat-label">PII masked</span>
         </div>
       </section>

--- a/chrome-extension/popup.js
+++ b/chrome-extension/popup.js
@@ -46,10 +46,11 @@ function setStatus({ connected, host, backendUrl }) {
   }
 }
 
-function setStats({ checksTotal = 0, piiFound = 0 }) {
+function setStats({ checksTotal = 0, piiMasked = 0 }) {
   document.getElementById("checks-total").textContent =
     checksTotal.toLocaleString();
-  document.getElementById("pii-found").textContent = piiFound.toLocaleString();
+  document.getElementById("pii-masked").textContent =
+    piiMasked.toLocaleString();
 }
 
 let lastBackendUrl = null;
@@ -66,7 +67,7 @@ function applyState(state) {
   });
   setStats({
     checksTotal: state.checksTotal ?? 0,
-    piiFound: state.piiFound ?? 0,
+    piiMasked: state.piiMasked ?? 0,
   });
 }
 
@@ -90,9 +91,9 @@ function subscribeToLiveUpdates() {
   chrome.storage.onChanged.addListener((changes, area) => {
     if (area !== "local") return;
 
-    if (changes.connected || changes.checksTotal || changes.piiFound) {
+    if (changes.connected || changes.checksTotal || changes.piiMasked) {
       chrome.storage.local.get(
-        { connected: false, checksTotal: 0, piiFound: 0 },
+        { connected: false, checksTotal: 0, piiMasked: 0 },
         (result) => {
           applyState({ ...result, backendUrl: lastBackendUrl });
         }

--- a/docs/06-chrome-extension.md
+++ b/docs/06-chrome-extension.md
@@ -60,7 +60,7 @@ chrome-extension/
 1. `background.js` dynamically registers `content.js` on user-configured domains
 2. `content.js` intercepts form submission, sends text to the backend `/api/pii/check` endpoint
 3. If PII is found, a modal is shown with mask/cancel/send options
-4. `content.js` reports check results to `background.js` for stats tracking
+4. `background.js` records each completed check, and `content.js` reports how many entities were masked when the masked version is used
 5. `background.js` runs periodic health checks and updates the badge icon
 
 ## Configuration
@@ -176,7 +176,7 @@ Required for any extension that handles user data. Host it at a public URL (GitH
 
 - **What data is collected:** Text from chat input fields on configured domains, only at the moment of submission
 - **Where data is sent:** To a user-configured backend server (default: localhost). No data is sent to third parties.
-- **What is stored:** The extension stores settings (backend URL, domain list) and session statistics (check count, PII detection count) locally. No message content is stored.
+- **What is stored:** The extension stores settings (backend URL, domain list) and session statistics (check count, masked PII entity count) locally. No message content is stored.
 - **Data retention:** Session statistics are cleared on extension reinstall. No message content is retained.
 - **User control:** Users choose which domains are intercepted and where data is sent. All PII checking can be bypassed via "Send Anyway."
 


### PR DESCRIPTION
## Summary
- fix the popup counter so Messages checked increments once per successful backend check
- count PII masked as masked entity count when the user chooses the masked version
- update extension privacy/docs wording for the new stat semantics

## Scope check
Only chrome-extension files plus docs/06-chrome-extension.md are changed; no model, backend detector, or tests changes are included.

## Verification
- node --check chrome-extension/background.js
- node --check chrome-extension/content.js
- node --check chrome-extension/popup.js
- git diff --check