### PR TITLE
fix: updated release flow and local dmg build

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -134,7 +134,7 @@ jobs:
         run: |
           git lfs pull
           # Verify model file is not an LFS pointer
-          MODEL_SIZE=$(stat -f%z "model/quantized/model_quantized.onnx" 2>/dev/null || echo "0")
+          MODEL_SIZE=$(stat -f%z "model/quantized/model.onnx" 2>/dev/null || echo "0")
           echo "Model file size: ${MODEL_SIZE} bytes"
           if [ "$MODEL_SIZE" -lt 1000 ]; then
             echo "❌ Model file appears to be an LFS pointer (too small)"
@@ -299,7 +299,7 @@ jobs:
         run: |
           git lfs pull
           # Verify model file is not an LFS pointer
-          MODEL_SIZE=$(stat -c%s "model/quantized/model_quantized.onnx" 2>/dev/null || echo "0")
+          MODEL_SIZE=$(stat -c%s "model/quantized/model.onnx" 2>/dev/null || echo "0")
           echo "Model file size: ${MODEL_SIZE} bytes"
           if [ "$MODEL_SIZE" -lt 1000 ]; then
             echo "❌ Model file appears to be an LFS pointer (too small)"

--- a/src/frontend/package.json
+++ b/src/frontend/package.json
@@ -149,7 +149,8 @@
       },
       "format": "UDZO",
       "artifactName": "${productName}-${version}.${ext}",
-      "sign": false
+      "sign": false,
+      "size": "3g"
     },
     "win": {
       "target": [

--- a/src/scripts/build_dmg.sh
+++ b/src/scripts/build_dmg.sh
@@ -396,6 +396,17 @@ ln -sfn ../../../node_modules/electron-builder node_modules/electron-builder
 ln -sfn ../../../node_modules/electron-updater node_modules/electron-updater
 ln -sfn ../../../node_modules/@sentry node_modules/@sentry
 
+# Force @electron/osx-sign to use isbinaryfile v5 (root copy) instead of its nested v4.
+# v4.0.10 crashes with "RangeError: Invalid array length" while signing large protobuf
+# files like the unquantized ONNX model — its protobuf detection lacks an early-exit
+# guard that v5+ has. Deleting the nested copy lets Node's module resolution fall back
+# to the v5 already at the workspace root.
+PROXY_NESTED_ISBF="$PROJECT_ROOT/node_modules/@electron/osx-sign/node_modules/isbinaryfile"
+if [ -d "$PROXY_NESTED_ISBF" ]; then
+    rm -rf "$PROXY_NESTED_ISBF"
+    echo "✅ Removed nested isbinaryfile@4 from @electron/osx-sign (uses root v5)"
+fi
+
 # Verify symlinks
 if [ -L "node_modules/electron" ]; then
     echo "✅ Electron symlink created"


### PR DESCRIPTION
With the recent change to using the raw model, the following parts needed an update:
- tell the release flow to use the raw vs the quant model
- the local build needed a size parameter now since the app grew in size