### PR TITLE
chore: add 1.0.0 release changeset

### DIFF
--- a/.changeset/humble-coats-do.md
+++ b/.changeset/humble-coats-do.md
@@ -1,0 +1,5 @@
+---
+"kiji-privacy-proxy": major
+---
+
+Promote Kiji Privacy Proxy to 1.0.0 (general availability).


### PR DESCRIPTION
Adds a major changeset to promote Kiji Privacy Proxy to 1.0.0 (general availability), bumping from 0.6.1.