### PR TITLE
feat: support custom provider endpoint URL

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -56,6 +56,7 @@
       "version": "7.29.0",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -2072,7 +2073,6 @@
       "dev": true,
       "license": "BSD-2-Clause",
       "optional": true,
-      "peer": true,
       "dependencies": {
         "cross-dirname": "^0.1.0",
         "debug": "^4.3.4",
@@ -2092,7 +2092,6 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
-      "peer": true,
       "dependencies": {
         "graceful-fs": "^4.2.0",
         "jsonfile": "^6.0.1",
@@ -2107,7 +2106,6 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
-      "peer": true,
       "dependencies": {
         "universalify": "^2.0.0"
       },
@@ -2120,7 +2118,6 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
-      "peer": true,
       "engines": {
         "node": ">= 10.0.0"
       }
@@ -3231,6 +3228,7 @@
       "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.1.tgz",
       "integrity": "sha512-gLyJlPHPZYdAk1JENA9LeHejZe1Ti77/pTeFm/nMXmQH/HFZlcS/O2XJB+L8fkbrNSqhdtlvjBVjxwUYanNH5Q==",
       "license": "Apache-2.0",
+      "peer": true,
       "engines": {
         "node": ">=8.0.0"
       }
@@ -3252,6 +3250,7 @@
       "resolved": "https://registry.npmjs.org/@opentelemetry/context-async-hooks/-/context-async-hooks-2.6.1.tgz",
       "integrity": "sha512-XHzhwRNkBpeP8Fs/qjGrAf9r9PRv67wkJQ/7ZPaBQQ68DYlTBBx5MF9LvPx7mhuXcDessKK2b+DcxqwpgkcivQ==",
       "license": "Apache-2.0",
+      "peer": true,
       "engines": {
         "node": "^18.19.0 || >=20.6.0"
       },
@@ -3264,6 +3263,7 @@
       "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-2.6.1.tgz",
       "integrity": "sha512-8xHSGWpJP9wBxgBpnqGL0R3PbdWQndL1Qp50qrg71+B28zK5OQmUgcDKLJgzyAAV38t4tOyLMGDD60LneR5W8g==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@opentelemetry/semantic-conventions": "^1.29.0"
       },
@@ -3672,6 +3672,7 @@
       "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-2.6.1.tgz",
       "integrity": "sha512-lID/vxSuKWXM55XhAKNoYXu9Cutoq5hFdkbTdI/zDKQktXzcWBVhNsOkiZFTMU9UtEWuGRNe0HUgmsFldIdxVA==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@opentelemetry/core": "2.6.1",
         "@opentelemetry/semantic-conventions": "^1.29.0"
@@ -3688,6 +3689,7 @@
       "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-base/-/sdk-trace-base-2.6.1.tgz",
       "integrity": "sha512-r86ut4T1e8vNwB35CqCcKd45yzqH6/6Wzvpk2/cZB8PsPLlZFTvrh8yfOS3CYZYcUmAx4hHTZJ8AO8Dj8nrdhw==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@opentelemetry/core": "2.6.1",
         "@opentelemetry/resources": "2.6.1",
@@ -3705,6 +3707,7 @@
       "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.40.0.tgz",
       "integrity": "sha512-cifvXDhcqMwwTlTK04GBNeIe7yyo28Mfby85QXFe1Yk8nmi36Ab/5UQwptOx84SsoGNRg+EVSjwzfSZMy6pmlw==",
       "license": "Apache-2.0",
+      "peer": true,
       "engines": {
         "node": ">=14"
       }
@@ -4455,6 +4458,7 @@
       "integrity": "sha512-z9VXpC7MWrhfWipitjNdgCauoMLRdIILQsAEV+ZesIzBq/oUlxk0m3ApZuMFCXdnS4U7KrI+l3WRUEGQ8K1QKw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/prop-types": "*",
         "csstype": "^3.2.2"
@@ -4606,6 +4610,7 @@
       "integrity": "sha512-/Zb/xaIDfxeJnvishjGdcR4jmr7S+bda8PKNhRGdljDM+elXhlvN0FyPSsMnLmJUrVG9aPO6dof80wjMawsASg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.58.2",
         "@typescript-eslint/types": "8.58.2",
@@ -5019,6 +5024,7 @@
     "node_modules/acorn": {
       "version": "8.16.0",
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -5066,6 +5072,7 @@
       "version": "6.12.6",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
         "fast-json-stable-stringify": "^2.0.0",
@@ -5954,6 +5961,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.10.12",
         "caniuse-lite": "^1.0.30001782",
@@ -6637,8 +6645,7 @@
       "version": "0.1.0",
       "dev": true,
       "license": "MIT",
-      "optional": true,
-      "peer": true
+      "optional": true
     },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
@@ -7019,6 +7026,7 @@
       "version": "26.7.0",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "app-builder-lib": "26.7.0",
         "builder-util": "26.4.1",
@@ -7454,7 +7462,6 @@
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@electron/asar": "^3.2.1",
         "debug": "^4.1.1",
@@ -7778,6 +7785,7 @@
       "version": "9.39.2",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -10658,7 +10666,6 @@
       "version": "0.5.6",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "minimist": "^1.2.6"
       },
@@ -11414,6 +11421,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
@@ -11569,7 +11577,6 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
-      "peer": true,
       "dependencies": {
         "commander": "^9.4.0"
       },
@@ -11585,7 +11592,6 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
-      "peer": true,
       "engines": {
         "node": "^12.20.0 || >=14"
       }
@@ -11814,6 +11820,7 @@
     "node_modules/react": {
       "version": "18.3.1",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0"
       },
@@ -12171,7 +12178,6 @@
       "version": "2.6.3",
       "dev": true,
       "license": "ISC",
-      "peer": true,
       "dependencies": {
         "glob": "^7.1.3"
       },
@@ -12350,6 +12356,7 @@
       "version": "8.17.1",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "fast-uri": "^3.0.1",
@@ -13177,7 +13184,6 @@
       "version": "0.9.4",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "mkdirp": "^0.5.1",
         "rimraf": "~2.6.2"
@@ -13369,6 +13375,7 @@
       "version": "4.0.3",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -13448,7 +13455,8 @@
     "node_modules/tslib": {
       "version": "2.8.1",
       "dev": true,
-      "license": "0BSD"
+      "license": "0BSD",
+      "peer": true
     },
     "node_modules/tsyringe": {
       "version": "4.10.0",
@@ -13562,6 +13570,7 @@
       "version": "5.9.3",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -13784,6 +13793,7 @@
       "version": "5.105.4",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/eslint-scope": "^3.7.7",
         "@types/estree": "^1.0.8",
@@ -13933,6 +13943,7 @@
       "version": "5.2.3",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/bonjour": "^3.5.13",
         "@types/connect-history-api-fallback": "^1.5.4",
@@ -14325,6 +14336,7 @@
       "version": "4.3.6",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }
@@ -14342,7 +14354,7 @@
     },
     "src/frontend": {
       "name": "kiji-privacy-proxy",
-      "version": "0.6.1",
+      "version": "1.0.0",
       "dependencies": {
         "@sentry/electron": "^7.11.0",
         "@types/dompurify": "^3.2.0",

--- a/src/backend/config/config.go
+++ b/src/backend/config/config.go
@@ -3,6 +3,8 @@ package config
 import (
 	"errors"
 	"fmt"
+	"net"
+	"net/url"
 	"path/filepath"
 	"regexp"
 	"strconv"
@@ -45,6 +47,7 @@ type ProvidersConfig struct {
 	AnthropicProviderConfig ProviderConfig         `json:"anthropic_provider_config"`
 	GeminiProviderConfig    ProviderConfig         `json:"gemini_provider_config"`
 	MistralProviderConfig   ProviderConfig         `json:"mistral_provider_config"`
+	CustomProviderConfig    ProviderConfig         `json:"custom_provider_config"`
 }
 
 // ProxyConfig holds transparent proxy configuration
@@ -95,6 +98,9 @@ func (c *Config) ValidateConfig() error {
 	if err := validateProviderConfig(c.Providers.MistralProviderConfig, "Mistral"); err != nil {
 		errs = append(errs, err.Error())
 	}
+	if err := validateProviderConfig(c.Providers.CustomProviderConfig, "Custom"); err != nil {
+		errs = append(errs, err.Error())
+	}
 
 	if len(errs) > 0 {
 		return errors.New(strings.Join(errs, "; "))
@@ -138,11 +144,23 @@ func validateDomain(domain string, fieldName string) error {
 	if domain == "" {
 		return fmt.Errorf("%s: domain cannot be empty", fieldName)
 	}
-	if strings.HasPrefix(domain, "http://") || strings.HasPrefix(domain, "https://") {
-		return fmt.Errorf("%s: domain must not include protocol 'http://' or 'https://' (current value: %s)", fieldName, domain)
+
+	value := strings.TrimSpace(domain)
+	if !strings.HasPrefix(value, "http://") && !strings.HasPrefix(value, "https://") {
+		value = "//" + value
 	}
+
+	parsed, err := url.Parse(value)
+	if err != nil || parsed.Host == "" {
+		return fmt.Errorf("%s: domain format is invalid (current value: %s)", fieldName, domain)
+	}
+	if parsed.Scheme != "" && parsed.Scheme != "http" && parsed.Scheme != "https" {
+		return fmt.Errorf("%s: domain format is invalid (current value: %s)", fieldName, domain)
+	}
+
+	host := parsed.Hostname()
 	domainRegex := regexp.MustCompile(`^[a-zA-Z0-9]([a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?(\.[a-zA-Z0-9]([a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?)*$`)
-	if !domainRegex.MatchString(domain) {
+	if net.ParseIP(host) == nil && !domainRegex.MatchString(host) {
 		return fmt.Errorf("%s: domain format is invalid (current value: %s)", fieldName, domain)
 	}
 	return nil
@@ -183,6 +201,10 @@ func DefaultConfig() *Config {
 		APIDomain:         providers.ProviderAPIDomainMistral,
 		AdditionalHeaders: map[string]string{},
 	}
+	defaultCustomProviderConfig := ProviderConfig{
+		APIDomain:         providers.ProviderAPIDomainCustom,
+		AdditionalHeaders: map[string]string{},
+	}
 
 	// Application data directory
 	appDataDir := paths.AppDataDir()
@@ -197,6 +219,7 @@ func DefaultConfig() *Config {
 			AnthropicProviderConfig: defaultAnthropicProviderConfig,
 			GeminiProviderConfig:    defaultGeminiProviderConfig,
 			MistralProviderConfig:   defaultMistralProviderConfig,
+			CustomProviderConfig:    defaultCustomProviderConfig,
 		},
 		ProxyPort:          ":8080",
 		ONNXModelPath:      "model/quantized/model.onnx",
@@ -227,11 +250,28 @@ func DefaultConfig() *Config {
 // GetInterceptDomains returns the list of intercept domains (as a union of all provider domains)
 func (pc ProvidersConfig) GetInterceptDomains() []string {
 	return []string{
-		pc.AnthropicProviderConfig.APIDomain,
-		pc.OpenAIProviderConfig.APIDomain,
-		pc.GeminiProviderConfig.APIDomain,
-		pc.MistralProviderConfig.APIDomain,
+		interceptDomain(pc.AnthropicProviderConfig.APIDomain),
+		interceptDomain(pc.OpenAIProviderConfig.APIDomain),
+		interceptDomain(pc.GeminiProviderConfig.APIDomain),
+		interceptDomain(pc.MistralProviderConfig.APIDomain),
+		interceptDomain(pc.CustomProviderConfig.APIDomain),
 	}
+}
+
+func interceptDomain(apiDomain string) string {
+	if apiDomain == "" {
+		return ""
+	}
+
+	value := apiDomain
+	if !strings.HasPrefix(value, "http://") && !strings.HasPrefix(value, "https://") {
+		value = "//" + value
+	}
+
+	if parsed, err := url.Parse(value); err == nil && parsed.Host != "" {
+		return parsed.Hostname()
+	}
+	return apiDomain
 }
 
 // GetLogPIIChanges returns whether to log PII changes

--- a/src/backend/config/config_test.go
+++ b/src/backend/config/config_test.go
@@ -94,18 +94,22 @@ func TestValidateDomain(t *testing.T) {
 			errString: "OpenAI.APIDomain: domain cannot be empty",
 		},
 		{
-			name:      "with http",
+			name:      "valid full URL with http",
 			domain:    "http://api.openai.com",
 			fieldName: "OpenAI.APIDomain",
-			expectErr: true,
-			errString: "OpenAI.APIDomain: domain must not include protocol 'http://' or 'https://' (current value: http://api.openai.com)",
+			expectErr: false,
 		},
 		{
-			name:      "with https",
-			domain:    "https://api.openai.com",
+			name:      "valid full URL with path",
+			domain:    "https://api.openai.com/v1",
 			fieldName: "OpenAI.APIDomain",
-			expectErr: true,
-			errString: "OpenAI.APIDomain: domain must not include protocol 'http://' or 'https://' (current value: https://api.openai.com)",
+			expectErr: false,
+		},
+		{
+			name:      "valid localhost with port",
+			domain:    "localhost:11434",
+			fieldName: "OpenAI.APIDomain",
+			expectErr: false,
 		},
 		{
 			name:      "invalid format",
@@ -205,11 +209,11 @@ func TestValidateProviderConfig(t *testing.T) {
 		{
 			name: "invalid domain",
 			providerCfg: ProviderConfig{
-				APIDomain: "http://api.openai.com",
+				APIDomain: "invalid_domain",
 			},
 			providerName: "OpenAI",
 			expectErr:    true,
-			errString:    "OpenAI.APIDomain: domain must not include protocol 'http://' or 'https://' (current value: http://api.openai.com)",
+			errString:    "OpenAI.APIDomain: domain format is invalid (current value: invalid_domain)",
 		},
 		{
 			name: "invalid headers",

--- a/src/backend/main.go
+++ b/src/backend/main.go
@@ -254,6 +254,17 @@ func loadApplicationConfig(cfg *config.Config) {
 		log.Printf("Warning: MISTRAL_API_KEY is empty or not set")
 	}
 
+	// Override Custom provider config with environment variables
+	if customURL := os.Getenv("CUSTOM_BASE_URL"); customURL != "" {
+		cfg.Providers.CustomProviderConfig.APIDomain = customURL
+	}
+	if customApiKey := os.Getenv("CUSTOM_API_KEY"); customApiKey != "" {
+		cfg.Providers.CustomProviderConfig.APIKey = customApiKey
+		log.Printf("Loaded CUSTOM_API_KEY from environment (length: %d)", len(customApiKey))
+	} else {
+		log.Printf("Warning: CUSTOM_API_KEY is empty or not set")
+	}
+
 	if modelDir := os.Getenv("ONNX_MODEL_DIRECTORY"); modelDir != "" {
 		cfg.ONNXModelDirectory = modelDir
 		log.Printf("Loaded ONNX_MODEL_DIRECTORY from environment: %s", modelDir)

--- a/src/backend/providers/custom.go
+++ b/src/backend/providers/custom.go
@@ -1,0 +1,44 @@
+package providers
+
+import (
+	"net/http"
+	"strings"
+)
+
+const (
+	ProviderTypeCustom      ProviderType = "custom"
+	ProviderAPIDomainCustom string       = "api.openai.com"
+)
+
+// CustomProvider uses the OpenAI-compatible chat completions API shape.
+type CustomProvider struct {
+	*OpenAIProvider
+}
+
+func NewCustomProvider(apiDomain string, apiKey string, additionalHeaders map[string]string) *CustomProvider {
+	return &CustomProvider{
+		OpenAIProvider: NewOpenAIProvider(apiDomain, apiKey, additionalHeaders),
+	}
+}
+
+func (p *CustomProvider) GetName() string {
+	return "Custom Provider"
+}
+
+func (p *CustomProvider) GetType() ProviderType {
+	return ProviderTypeCustom
+}
+
+func (p *CustomProvider) SetAuthHeaders(req *http.Request) {
+	if apiKey := req.Header.Get("X-OpenAI-API-Key"); apiKey != "" {
+		return
+	} else if apiKey := req.Header.Get("Authorization"); apiKey != "" {
+		return
+	}
+
+	if strings.TrimSpace(p.apiKey) == "" {
+		return
+	}
+
+	req.Header.Set("Authorization", "Bearer "+p.apiKey)
+}

--- a/src/backend/providers/provider.go
+++ b/src/backend/providers/provider.go
@@ -23,11 +23,6 @@ func normalizeBaseURL(apiDomain string, useHttps bool) string {
 	// If apiDomain already has a scheme, parse it as-is
 	if strings.HasPrefix(apiDomain, "https://") || strings.HasPrefix(apiDomain, "http://") {
 		if parsed, err := url.Parse(apiDomain); err == nil {
-			if useHttps {
-				parsed.Scheme = "https"
-			} else {
-				parsed.Scheme = "http"
-			}
 			return strings.TrimSuffix(parsed.String(), "/")
 		}
 	}
@@ -83,6 +78,7 @@ type Providers struct {
 	AnthropicProvider *AnthropicProvider
 	GeminiProvider    *GeminiProvider
 	MistralProvider   *MistralProvider
+	CustomProvider    *CustomProvider
 }
 
 type ProviderRequest struct {
@@ -122,6 +118,8 @@ func (p *Providers) GetProviderFromPath(host string, path string, body *[]byte, 
 				provider = p.GeminiProvider
 			case ProviderTypeMistral:
 				provider = p.MistralProvider
+			case ProviderTypeCustom:
+				provider = p.CustomProvider
 			default:
 				log.Printf("%s [Provider] provider could not be determined from 'provider' field in request body, unknown provider: '%s'.", logPrefix, provider_field)
 			}
@@ -174,15 +172,17 @@ func (p *Providers) GetProviderFromHost(host string, logPrefix string) (*Provide
 		host = h
 	}
 
-	switch host {
-	case p.OpenAIProvider.apiDomain:
+	switch {
+	case p.OpenAIProvider != nil && providerHostMatches(host, p.OpenAIProvider.apiDomain):
 		provider = p.OpenAIProvider
-	case p.AnthropicProvider.apiDomain:
+	case p.AnthropicProvider != nil && providerHostMatches(host, p.AnthropicProvider.apiDomain):
 		provider = p.AnthropicProvider
-	case p.GeminiProvider.apiDomain:
+	case p.GeminiProvider != nil && providerHostMatches(host, p.GeminiProvider.apiDomain):
 		provider = p.GeminiProvider
-	case p.MistralProvider.apiDomain:
+	case p.MistralProvider != nil && providerHostMatches(host, p.MistralProvider.apiDomain):
 		provider = p.MistralProvider
+	case p.CustomProvider != nil && providerHostMatches(host, p.CustomProvider.apiDomain):
+		provider = p.CustomProvider
 	default:
 		log.Printf("%s [Provider] provider could not be determined from host '%s'.", logPrefix, host)
 		return &provider, fmt.Errorf("provider could not be determined from host: '%s'", host)
@@ -190,4 +190,29 @@ func (p *Providers) GetProviderFromHost(host string, logPrefix string) (*Provide
 
 	log.Printf("%s [Provider] '%s' provider detected from host '%s'.", logPrefix, provider.GetName(), host)
 	return &provider, nil
+}
+
+func providerHostMatches(host string, apiDomain string) bool {
+	return host == providerHost(apiDomain)
+}
+
+func providerHost(apiDomain string) string {
+	if apiDomain == "" {
+		return ""
+	}
+
+	value := apiDomain
+	if !strings.HasPrefix(value, "http://") && !strings.HasPrefix(value, "https://") {
+		value = "//" + value
+	}
+
+	if parsed, err := url.Parse(value); err == nil && parsed.Host != "" {
+		return parsed.Hostname()
+	}
+
+	host := strings.Split(apiDomain, "/")[0]
+	if h, _, err := net.SplitHostPort(host); err == nil {
+		return h
+	}
+	return host
 }

--- a/src/backend/providers/provider_test.go
+++ b/src/backend/providers/provider_test.go
@@ -31,16 +31,16 @@ func TestNormalizeBaseURL(t *testing.T) {
 			want:      "https://api.openai.com/v1",
 		},
 		{
-			name:      "full http URL upgraded to https",
+			name:      "full http URL keeps explicit scheme",
 			apiDomain: "http://api.openai.com/v1",
 			useHttps:  true,
-			want:      "https://api.openai.com/v1",
+			want:      "http://api.openai.com/v1",
 		},
 		{
-			name:      "full https URL downgraded to http",
+			name:      "full https URL keeps explicit scheme",
 			apiDomain: "https://api.openai.com/v1",
 			useHttps:  false,
-			want:      "http://api.openai.com/v1",
+			want:      "https://api.openai.com/v1",
 		},
 
 		// Trailing slash stripped

--- a/src/backend/providers/providers_test.go
+++ b/src/backend/providers/providers_test.go
@@ -816,6 +816,7 @@ func newTestProviders(defaultOpenAI ProviderType) *Providers {
 		AnthropicProvider: NewAnthropicProvider("api.anthropic.com", "sk-ant", nil),
 		GeminiProvider:    NewGeminiProvider("generativelanguage.googleapis.com", "AIza", nil),
 		MistralProvider:   NewMistralProvider("api.mistral.ai", "sk-mistral", nil),
+		CustomProvider:    NewCustomProvider("custom.example.com", "sk-custom", nil),
 	}
 }
 
@@ -891,6 +892,13 @@ func TestProviders_GetProviderFromPath(t *testing.T) {
 			defaultOAI:   ProviderTypeOpenAI,
 			wantProvider: "Mistral",
 		},
+		{
+			name:         "provider field custom",
+			path:         "/v1/chat/completions",
+			body:         `{"provider":"custom","model":"custom-model","messages":[]}`,
+			defaultOAI:   ProviderTypeOpenAI,
+			wantProvider: "Custom Provider",
+		},
 	}
 
 	for _, tt := range tests {
@@ -941,6 +949,7 @@ func TestProviders_GetProviderFromHost(t *testing.T) {
 		{"Anthropic host", "api.anthropic.com", "Anthropic", false},
 		{"Gemini host", "generativelanguage.googleapis.com", "Gemini", false},
 		{"Mistral host", "api.mistral.ai", "Mistral", false},
+		{"Custom host", "custom.example.com", "Custom Provider", false},
 		{"unknown host", "unknown.example.com", "", true},
 	}
 

--- a/src/backend/proxy/handler.go
+++ b/src/backend/proxy/handler.go
@@ -557,6 +557,11 @@ func NewHandler(cfg *config.Config) (*Handler, error) {
 		cfg.Providers.MistralProviderConfig.APIKey,
 		cfg.Providers.MistralProviderConfig.AdditionalHeaders,
 	)
+	customProvider := providers.NewCustomProvider(
+		cfg.Providers.CustomProviderConfig.APIDomain,
+		cfg.Providers.CustomProviderConfig.APIKey,
+		cfg.Providers.CustomProviderConfig.AdditionalHeaders,
+	)
 
 	defaultProviders, err := providers.NewDefaultProviders(
 		cfg.Providers.DefaultProvidersConfig.OpenAISubpath,
@@ -571,6 +576,7 @@ func NewHandler(cfg *config.Config) (*Handler, error) {
 		AnthropicProvider: anthropicProvider,
 		GeminiProvider:    geminiProvider,
 		MistralProvider:   mistralProvider,
+		CustomProvider:    customProvider,
 	}
 
 	// Create services

--- a/src/backend/proxy/handler_test.go
+++ b/src/backend/proxy/handler_test.go
@@ -184,6 +184,11 @@ func newTestHandler(t *testing.T, detector *mockDetector, upstreamServer *httpte
 				APIKey:            "sk-mistral-test",
 				AdditionalHeaders: map[string]string{},
 			},
+			CustomProviderConfig: config.ProviderConfig{
+				APIDomain:         "custom.example.com",
+				APIKey:            "sk-custom-test",
+				AdditionalHeaders: map[string]string{},
+			},
 		},
 		Logging: config.LoggingConfig{
 			LogRequests:    true,
@@ -214,6 +219,11 @@ func newTestHandler(t *testing.T, detector *mockDetector, upstreamServer *httpte
 		cfg.Providers.MistralProviderConfig.APIKey,
 		cfg.Providers.MistralProviderConfig.AdditionalHeaders,
 	)
+	customProvider := providers.NewCustomProvider(
+		cfg.Providers.CustomProviderConfig.APIDomain,
+		cfg.Providers.CustomProviderConfig.APIKey,
+		cfg.Providers.CustomProviderConfig.AdditionalHeaders,
+	)
 
 	defaultProviders, err := providers.NewDefaultProviders(cfg.Providers.DefaultProvidersConfig.OpenAISubpath)
 	if err != nil {
@@ -226,6 +236,7 @@ func newTestHandler(t *testing.T, detector *mockDetector, upstreamServer *httpte
 		AnthropicProvider: anthropicProvider,
 		GeminiProvider:    geminiProvider,
 		MistralProvider:   mistralProvider,
+		CustomProvider:    customProvider,
 	}
 
 	var det pii.Detector = detector
@@ -816,6 +827,7 @@ func TestHandler_ServeHTTP_Integration(t *testing.T) {
 		AnthropicProvider: providers.NewAnthropicProvider("api.anthropic.com", "sk-ant", nil),
 		GeminiProvider:    providers.NewGeminiProvider("generativelanguage.googleapis.com", "key", nil),
 		MistralProvider:   providers.NewMistralProvider("api.mistral.ai", "key", nil),
+		CustomProvider:    providers.NewCustomProvider("custom.example.com", "key", nil),
 	}
 
 	body := `{"model":"gpt-4","messages":[{"role":"user","content":"Hello world"}]}`
@@ -909,6 +921,7 @@ func TestHandler_ServeHTTP_DetailsQueryParam(t *testing.T) {
 		AnthropicProvider: providers.NewAnthropicProvider("api.anthropic.com", "sk-ant", nil),
 		GeminiProvider:    providers.NewGeminiProvider("generativelanguage.googleapis.com", "key", nil),
 		MistralProvider:   providers.NewMistralProvider("api.mistral.ai", "key", nil),
+		CustomProvider:    providers.NewCustomProvider("custom.example.com", "key", nil),
 	}
 
 	body := `{"model":"gpt-4","messages":[{"role":"user","content":"Hello world"}]}`

--- a/src/backend/server/server.go
+++ b/src/backend/server/server.go
@@ -183,6 +183,7 @@ func (s *Server) Start() error {
 	log.Printf("Forward Anthropic requests to: %s", s.config.Providers.AnthropicProviderConfig.APIDomain)
 	log.Printf("Forward Gemini requests to: %s", s.config.Providers.GeminiProviderConfig.APIDomain)
 	log.Printf("Forward Mistral requests to: %s", s.config.Providers.MistralProviderConfig.APIDomain)
+	log.Printf("Forward Custom Provider requests to: %s", s.config.Providers.CustomProviderConfig.APIDomain)
 
 	if s.handler != nil {
 		log.Println("PII detection enabled with ONNX model detector")

--- a/src/frontend/src/components/modals/SettingsModal.tsx
+++ b/src/frontend/src/components/modals/SettingsModal.tsx
@@ -12,6 +12,7 @@ import {
   Settings2,
   Lock,
   Unlock,
+  Globe,
 } from "lucide-react";
 
 type ProviderType = "openai" | "anthropic" | "gemini" | "mistral";
@@ -19,7 +20,16 @@ type ProviderType = "openai" | "anthropic" | "gemini" | "mistral";
 interface ProviderSettings {
   hasApiKey: boolean;
   model: string;
+  baseUrl?: string;
 }
+
+// Providers that support a user-configurable custom endpoint URL.
+// OpenAI's API shape is also implemented by many third-party servers
+// (LM Studio, Ollama, Together, vLLM, …), so we expose the base URL
+// only for that provider for now.
+const PROVIDERS_WITH_CUSTOM_ENDPOINT: ReadonlySet<ProviderType> = new Set([
+  "openai",
+]);
 
 interface ProvidersConfig {
   activeProvider: ProviderType;
@@ -29,7 +39,14 @@ interface ProvidersConfig {
 // Provider display information
 const PROVIDER_INFO: Record<
   ProviderType,
-  { name: string; defaultModel: string; placeholder: string; helpLink: string }
+  {
+    name: string;
+    defaultModel: string;
+    placeholder: string;
+    helpLink: string;
+    defaultBaseUrl?: string;
+    baseUrlPlaceholder?: string;
+  }
 > = {
   openai: {
     name: "OpenAI",
@@ -37,6 +54,8 @@ const PROVIDER_INFO: Record<
     placeholder: "sk-...",
     helpLink:
       "https://help.openai.com/en/articles/4936850-where-do-i-find-my-openai-api-key",
+    defaultBaseUrl: "https://api.openai.com/v1",
+    baseUrlPlaceholder: "https://api.openai.com/v1",
   },
   anthropic: {
     name: "Anthropic",
@@ -128,6 +147,15 @@ export default function SettingsModal({
     mistral: "",
   });
 
+  const [providerBaseUrls, setProviderBaseUrls] = useState<
+    Record<ProviderType, string>
+  >({
+    openai: "",
+    anthropic: "",
+    gemini: "",
+    mistral: "",
+  });
+
   const loadSettings = async () => {
     if (!window.electronAPI) return;
 
@@ -136,8 +164,14 @@ export default function SettingsModal({
       const config = await window.electronAPI.getProvidersConfig();
       setProvidersConfig(config);
 
-      // Load models from config
+      // Load models and base URLs from config
       const models: Record<ProviderType, string> = {
+        openai: "",
+        anthropic: "",
+        gemini: "",
+        mistral: "",
+      };
+      const baseUrls: Record<ProviderType, string> = {
         openai: "",
         anthropic: "",
         gemini: "",
@@ -145,8 +179,10 @@ export default function SettingsModal({
       };
       for (const provider of PROVIDER_ORDER) {
         models[provider] = config.providers[provider]?.model || "";
+        baseUrls[provider] = config.providers[provider]?.baseUrl || "";
       }
       setProviderModels(models);
+      setProviderBaseUrls(baseUrls);
 
       // Clear API key inputs
       setProviderApiKeys({
@@ -212,9 +248,26 @@ export default function SettingsModal({
           setIsSaving(false);
           return;
         }
-      }
 
-      setMessage({ type: "success", text: "Settings saved successfully!" });
+        // Save custom base URL (only meaningful for providers that expose it,
+        // but the backend stores it generically per provider)
+        if (PROVIDERS_WITH_CUSTOM_ENDPOINT.has(provider)) {
+          const baseUrlResult = await window.electronAPI.setProviderBaseUrl(
+            provider,
+            providerBaseUrls[provider].trim()
+          );
+          if (!baseUrlResult.success) {
+            setMessage({
+              type: "error",
+              text:
+                baseUrlResult.error ||
+                `Failed to save ${PROVIDER_INFO[provider].name} endpoint URL`,
+            });
+            setIsSaving(false);
+            return;
+          }
+        }
+      }
 
       // Reload config to update hasApiKey status
       const updatedConfig = await window.electronAPI.getProvidersConfig();
@@ -227,6 +280,23 @@ export default function SettingsModal({
         gemini: "",
         mistral: "",
       });
+
+      // Restart the backend so the new API keys / endpoint URLs take effect.
+      // Without this, the Go process keeps using whatever env vars it spawned with.
+      setMessage({ type: "success", text: "Saved. Restarting backend..." });
+      const restartResult = await window.electronAPI.restartBackend();
+      if (!restartResult.success) {
+        setMessage({
+          type: "error",
+          text:
+            restartResult.error ||
+            "Settings saved, but backend restart failed. Restart the app to apply.",
+        });
+        setIsSaving(false);
+        return;
+      }
+
+      setMessage({ type: "success", text: "Settings saved and applied!" });
 
       setTimeout(() => {
         onClose();
@@ -483,6 +553,36 @@ export default function SettingsModal({
                               Default: {info.defaultModel}
                             </p>
                           </div>
+
+                          {/* Custom Endpoint URL (OpenAI-compatible providers only) */}
+                          {PROVIDERS_WITH_CUSTOM_ENDPOINT.has(provider) && (
+                            <div>
+                              <label className="block text-sm font-medium text-slate-600 mb-2 flex items-center gap-2">
+                                <Globe className="w-4 h-4" />
+                                Custom Endpoint URL
+                              </label>
+                              <input
+                                type="url"
+                                value={providerBaseUrls[provider]}
+                                onChange={(e) =>
+                                  setProviderBaseUrls((prev) => ({
+                                    ...prev,
+                                    [provider]: e.target.value,
+                                  }))
+                                }
+                                placeholder={
+                                  info.baseUrlPlaceholder ||
+                                  "https://api.example.com/v1"
+                                }
+                                className="w-full px-3 py-2 border border-slate-300 rounded-lg focus:border-blue-500 focus:outline-none font-mono text-sm placeholder:text-gray-400"
+                              />
+                              <p className="text-xs text-slate-500 mt-1">
+                                {info.defaultBaseUrl
+                                  ? `Default: ${info.defaultBaseUrl}. Override to use an OpenAI-compatible endpoint (LM Studio, Ollama, vLLM, etc.).`
+                                  : "Override to use a custom endpoint."}
+                              </p>
+                            </div>
+                          )}
                         </div>
                       )}
                     </div>

--- a/src/frontend/src/components/modals/SettingsModal.tsx
+++ b/src/frontend/src/components/modals/SettingsModal.tsx
@@ -1,5 +1,6 @@
 import { useState, useEffect } from "react";
 import { isElectron } from "../../utils/providerHelpers";
+import type { ProvidersConfig, ProviderType } from "../../types/provider";
 import {
   X,
   Save,
@@ -15,26 +16,10 @@ import {
   Globe,
 } from "lucide-react";
 
-type ProviderType = "openai" | "anthropic" | "gemini" | "mistral";
-
-interface ProviderSettings {
-  hasApiKey: boolean;
-  model: string;
-  baseUrl?: string;
-}
-
 // Providers that support a user-configurable custom endpoint URL.
-// OpenAI's API shape is also implemented by many third-party servers
-// (LM Studio, Ollama, Together, vLLM, …), so we expose the base URL
-// only for that provider for now.
 const PROVIDERS_WITH_CUSTOM_ENDPOINT: ReadonlySet<ProviderType> = new Set([
-  "openai",
+  "custom",
 ]);
-
-interface ProvidersConfig {
-  activeProvider: ProviderType;
-  providers: Record<ProviderType, ProviderSettings>;
-}
 
 // Provider display information
 const PROVIDER_INFO: Record<
@@ -43,9 +28,11 @@ const PROVIDER_INFO: Record<
     name: string;
     defaultModel: string;
     placeholder: string;
-    helpLink: string;
-    defaultBaseUrl?: string;
+    helpLink?: string;
     baseUrlPlaceholder?: string;
+    modelHelpText?: string;
+    endpointHelpText?: string;
+    apiKeyOptional?: boolean;
   }
 > = {
   openai: {
@@ -54,8 +41,6 @@ const PROVIDER_INFO: Record<
     placeholder: "sk-...",
     helpLink:
       "https://help.openai.com/en/articles/4936850-where-do-i-find-my-openai-api-key",
-    defaultBaseUrl: "https://api.openai.com/v1",
-    baseUrlPlaceholder: "https://api.openai.com/v1",
   },
   anthropic: {
     name: "Anthropic",
@@ -75,6 +60,16 @@ const PROVIDER_INFO: Record<
     placeholder: "...",
     helpLink: "https://console.mistral.ai/api-keys",
   },
+  custom: {
+    name: "Custom Provider",
+    defaultModel: "your-model-id",
+    placeholder: "...",
+    baseUrlPlaceholder: "https://api.example.com/v1",
+    apiKeyOptional: true,
+    modelHelpText: "Use the exact model ID expected by your provider.",
+    endpointHelpText:
+      "Your custom provider must support an OpenAI-compliant chat completions API.",
+  },
 };
 
 const PROVIDER_ORDER: ProviderType[] = [
@@ -82,6 +77,7 @@ const PROVIDER_ORDER: ProviderType[] = [
   "anthropic",
   "gemini",
   "mistral",
+  "custom",
 ];
 
 interface SettingsModalProps {
@@ -110,6 +106,7 @@ export default function SettingsModal({
       anthropic: { hasApiKey: false, model: "" },
       gemini: { hasApiKey: false, model: "" },
       mistral: { hasApiKey: false, model: "" },
+      custom: { hasApiKey: false, model: "", baseUrl: "" },
     },
   });
 
@@ -126,6 +123,7 @@ export default function SettingsModal({
     anthropic: false,
     gemini: false,
     mistral: false,
+    custom: false,
   });
 
   // Form state for each provider (API key inputs and model overrides)
@@ -136,6 +134,7 @@ export default function SettingsModal({
     anthropic: "",
     gemini: "",
     mistral: "",
+    custom: "",
   });
 
   const [providerModels, setProviderModels] = useState<
@@ -145,6 +144,7 @@ export default function SettingsModal({
     anthropic: "",
     gemini: "",
     mistral: "",
+    custom: "",
   });
 
   const [providerBaseUrls, setProviderBaseUrls] = useState<
@@ -154,6 +154,7 @@ export default function SettingsModal({
     anthropic: "",
     gemini: "",
     mistral: "",
+    custom: "",
   });
 
   const loadSettings = async () => {
@@ -170,12 +171,14 @@ export default function SettingsModal({
         anthropic: "",
         gemini: "",
         mistral: "",
+        custom: "",
       };
       const baseUrls: Record<ProviderType, string> = {
         openai: "",
         anthropic: "",
         gemini: "",
         mistral: "",
+        custom: "",
       };
       for (const provider of PROVIDER_ORDER) {
         models[provider] = config.providers[provider]?.model || "";
@@ -190,6 +193,7 @@ export default function SettingsModal({
         anthropic: "",
         gemini: "",
         mistral: "",
+        custom: "",
       });
     } catch (error) {
       console.error("Error loading settings:", error);
@@ -279,6 +283,7 @@ export default function SettingsModal({
         anthropic: "",
         gemini: "",
         mistral: "",
+        custom: "",
       });
 
       // Restart the backend so the new API keys / endpoint URLs take effect.
@@ -409,6 +414,7 @@ export default function SettingsModal({
                   const info = PROVIDER_INFO[provider];
                   const config = providersConfig.providers[provider];
                   const isExpanded = expandedProvider === provider;
+                  const isApiKeyOptional = info.apiKeyOptional === true;
 
                   return (
                     <div
@@ -434,10 +440,16 @@ export default function SettingsModal({
                           className={`text-xs px-2 py-1 rounded ${
                             config?.hasApiKey
                               ? "bg-green-100 text-green-700"
+                              : isApiKeyOptional
+                              ? "bg-blue-100 text-blue-700"
                               : "bg-slate-100 text-slate-500"
                           }`}
                         >
-                          {config?.hasApiKey ? "Configured" : "Not Set"}
+                          {config?.hasApiKey
+                            ? "Configured"
+                            : isApiKeyOptional
+                            ? "Key Optional"
+                            : "Not Set"}
                         </span>
                       </button>
 
@@ -452,6 +464,7 @@ export default function SettingsModal({
                                 <label className="text-sm font-medium text-slate-600 flex items-center gap-2">
                                   <Key className="w-4 h-4" />
                                   {info.name} API Key
+                                  {isApiKeyOptional ? " (optional)" : ""}
                                 </label>
                                 {config?.hasApiKey && (
                                   <button
@@ -505,6 +518,8 @@ export default function SettingsModal({
                                     ? unlockedProviders[provider]
                                       ? "Enter new API key to update"
                                       : "API key is configured (unlock to edit)"
+                                    : isApiKeyOptional
+                                    ? `Optional ${info.name} API key (${info.placeholder})`
                                     : `Enter your ${info.name} API key (${info.placeholder})`
                                 }
                                 className={`w-full px-3 py-2 border rounded-lg focus:border-blue-500 focus:outline-none font-mono text-sm placeholder:text-gray-400 ${
@@ -521,14 +536,16 @@ export default function SettingsModal({
                             </div>
 
                             {/* Help link */}
-                            <a
-                              href={info.helpLink}
-                              target="_blank"
-                              rel="noopener noreferrer"
-                              className="inline-flex items-center gap-1 text-xs text-blue-600 hover:text-blue-800 hover:underline transition-colors mt-1"
-                            >
-                              How to get your {info.name} API key?
-                            </a>
+                            {info.helpLink && (
+                              <a
+                                href={info.helpLink}
+                                target="_blank"
+                                rel="noopener noreferrer"
+                                className="inline-flex items-center gap-1 text-xs text-blue-600 hover:text-blue-800 hover:underline transition-colors mt-1"
+                              >
+                                How to get your {info.name} API key?
+                              </a>
+                            )}
                           </div>
 
                           {/* Model Override */}
@@ -550,11 +567,11 @@ export default function SettingsModal({
                               className="w-full px-3 py-2 border border-slate-300 rounded-lg focus:border-blue-500 focus:outline-none font-mono text-sm placeholder:text-gray-400"
                             />
                             <p className="text-xs text-slate-500 mt-1">
-                              Default: {info.defaultModel}
+                              {info.modelHelpText || `Default: ${info.defaultModel}`}
                             </p>
                           </div>
 
-                          {/* Custom Endpoint URL (OpenAI-compatible providers only) */}
+                          {/* Custom Endpoint URL */}
                           {PROVIDERS_WITH_CUSTOM_ENDPOINT.has(provider) && (
                             <div>
                               <label className="block text-sm font-medium text-slate-600 mb-2 flex items-center gap-2">
@@ -576,11 +593,16 @@ export default function SettingsModal({
                                 }
                                 className="w-full px-3 py-2 border border-slate-300 rounded-lg focus:border-blue-500 focus:outline-none font-mono text-sm placeholder:text-gray-400"
                               />
-                              <p className="text-xs text-slate-500 mt-1">
-                                {info.defaultBaseUrl
-                                  ? `Default: ${info.defaultBaseUrl}. Override to use an OpenAI-compatible endpoint (LM Studio, Ollama, vLLM, etc.).`
-                                  : "Override to use a custom endpoint."}
-                              </p>
+                              {info.endpointHelpText ? (
+                                <p className="flex items-start gap-2 rounded-md border border-amber-200 bg-amber-50 px-3 py-2 text-xs text-amber-800 mt-2">
+                                  <AlertCircle className="w-4 h-4 shrink-0 mt-0.5" />
+                                  <span>{info.endpointHelpText}</span>
+                                </p>
+                              ) : (
+                                <p className="text-xs text-slate-500 mt-1">
+                                  Override to use a custom endpoint.
+                                </p>
+                              )}
                             </div>
                           )}
                         </div>

--- a/src/frontend/src/components/privacy-proxy-ui.tsx
+++ b/src/frontend/src/components/privacy-proxy-ui.tsx
@@ -264,7 +264,7 @@ export default function PrivacyProxyUI() {
             </div>
           )}
 
-          {isElectron && !settings.apiKey && (
+          {isElectron && !settings.apiKey && settings.activeProvider !== "custom" && (
             <div className="mt-4 p-2 bg-amber-50 border border-amber-200 rounded-lg inline-block">
               <p className="text-xs text-amber-800 flex items-center gap-2">
                 <AlertCircle className="w-4 h-4" />
@@ -308,6 +308,7 @@ export default function PrivacyProxyUI() {
                       "anthropic",
                       "gemini",
                       "mistral",
+                      "custom",
                     ] as ProviderType[]
                   ).map((provider) => (
                     <option key={provider} value={provider}>

--- a/src/frontend/src/electron/electron-main.js
+++ b/src/frontend/src/electron/electron-main.js
@@ -175,10 +175,11 @@ const getResourcesPath = () => {
 // Map of provider type → env var names understood by the Go backend.
 // Keep in sync with src/backend/main.go loadApplicationConfig().
 const PROVIDER_ENV_NAMES = {
-  openai: { apiKey: "OPENAI_API_KEY", baseUrl: "OPENAI_BASE_URL" },
+  openai: { apiKey: "OPENAI_API_KEY" },
   anthropic: { apiKey: "ANTHROPIC_API_KEY", baseUrl: "ANTHROPIC_BASE_URL" },
   gemini: { apiKey: "GEMINI_API_KEY", baseUrl: "GEMINI_BASE_URL" },
   mistral: { apiKey: "MISTRAL_API_KEY", baseUrl: "MISTRAL_BASE_URL" },
+  custom: { apiKey: "CUSTOM_API_KEY", baseUrl: "CUSTOM_BASE_URL" },
 };
 
 // Build env var pairs from the persisted Electron config so the Go backend
@@ -201,7 +202,7 @@ const buildProviderEnvFromConfig = () => {
       }
 
       const baseUrl = (providerCfg.baseUrl || "").trim();
-      if (baseUrl) {
+      if (baseUrl && names.baseUrl) {
         env[names.baseUrl] = baseUrl;
       }
     }
@@ -1110,7 +1111,7 @@ app.on("will-quit", () => {
 });
 
 // Valid provider types
-const VALID_PROVIDERS = ["openai", "anthropic", "gemini", "mistral"];
+const VALID_PROVIDERS = ["openai", "anthropic", "gemini", "mistral", "custom"];
 
 // Migrate old single-key config format to new multi-provider format
 const migrateConfig = (config) => {
@@ -1127,6 +1128,7 @@ const migrateConfig = (config) => {
     anthropic: { apiKey: "", encrypted: false, model: "" },
     gemini: { apiKey: "", encrypted: false, model: "" },
     mistral: { apiKey: "", encrypted: false, model: "" },
+    custom: { apiKey: "", encrypted: false, model: "", baseUrl: "" },
   };
 
   // Migrate old apiKey to openai provider
@@ -1478,6 +1480,7 @@ ipcMain.handle("get-providers-config", async () => {
         anthropic: { hasApiKey: false, model: "", baseUrl: "" },
         gemini: { hasApiKey: false, model: "", baseUrl: "" },
         mistral: { hasApiKey: false, model: "", baseUrl: "" },
+        custom: { hasApiKey: false, model: "", baseUrl: "" },
       },
     };
   }

--- a/src/frontend/src/electron/electron-main.js
+++ b/src/frontend/src/electron/electron-main.js
@@ -172,6 +172,45 @@ const getResourcesPath = () => {
 };
 
 // Launch the Go binary backend
+// Map of provider type → env var names understood by the Go backend.
+// Keep in sync with src/backend/main.go loadApplicationConfig().
+const PROVIDER_ENV_NAMES = {
+  openai: { apiKey: "OPENAI_API_KEY", baseUrl: "OPENAI_BASE_URL" },
+  anthropic: { apiKey: "ANTHROPIC_API_KEY", baseUrl: "ANTHROPIC_BASE_URL" },
+  gemini: { apiKey: "GEMINI_API_KEY", baseUrl: "GEMINI_BASE_URL" },
+  mistral: { apiKey: "MISTRAL_API_KEY", baseUrl: "MISTRAL_BASE_URL" },
+};
+
+// Build env var pairs from the persisted Electron config so the Go backend
+// picks up the user's saved API keys and custom endpoint URLs at spawn time.
+// Values from the saved config take precedence over inherited process.env
+// because they were explicitly set by the user via Settings.
+const buildProviderEnvFromConfig = () => {
+  const env = {};
+  try {
+    const cfg = readConfig();
+    const providers = cfg.providers || {};
+
+    for (const [provider, names] of Object.entries(PROVIDER_ENV_NAMES)) {
+      const providerCfg = providers[provider];
+      if (!providerCfg) continue;
+
+      const decryptedKey = decryptApiKey(providerCfg);
+      if (decryptedKey) {
+        env[names.apiKey] = decryptedKey;
+      }
+
+      const baseUrl = (providerCfg.baseUrl || "").trim();
+      if (baseUrl) {
+        env[names.baseUrl] = baseUrl;
+      }
+    }
+  } catch (error) {
+    console.error("Error building provider env from saved config:", error);
+  }
+  return env;
+};
+
 const launchGoBinary = () => {
   // Skip launching backend if EXTERNAL_BACKEND is set (e.g., running in debugger)
   if (
@@ -199,8 +238,10 @@ const launchGoBinary = () => {
   const projectRoot = getResourcesPath();
   console.log("[DEBUG] Project root / resources path:", projectRoot);
 
-  // Set up environment variables
-  const env = { ...process.env };
+  // Set up environment variables.
+  // Order matters: the saved provider config wins over inherited process.env
+  // because the user explicitly set those values via the Settings UI.
+  const env = { ...process.env, ...buildProviderEnvFromConfig() };
 
   // In development mode, set ONNX Runtime library path
   // Try multiple locations relative to project root
@@ -354,6 +395,47 @@ const stopGoBinary = () => {
       goProcess = null;
     }, 3000);
   }
+};
+
+// Stop the Go binary and wait for it to actually exit.
+// Returns once the process has terminated (or after a hard timeout).
+const stopGoBinaryAsync = () => {
+  return new Promise((resolve) => {
+    if (!goProcess) {
+      resolve();
+      return;
+    }
+
+    const proc = goProcess;
+    let settled = false;
+    const finish = () => {
+      if (settled) return;
+      settled = true;
+      goProcess = null;
+      resolve();
+    };
+
+    proc.once("exit", finish);
+    console.log("Stopping Go binary (async)...");
+    proc.kill("SIGTERM");
+
+    setTimeout(() => {
+      if (!settled) {
+        if (!proc.killed) {
+          console.log("Force killing Go binary (async)...");
+          proc.kill("SIGKILL");
+        }
+        // Give SIGKILL a brief moment, then resolve regardless.
+        setTimeout(finish, 500);
+      }
+    }, 3000);
+  });
+};
+
+// Restart the Go binary so it picks up updated env vars from the saved config.
+const restartGoBinary = async () => {
+  await stopGoBinaryAsync();
+  launchGoBinary();
 };
 
 // Wait for the Go backend to be ready by polling the health endpoint
@@ -1285,13 +1367,92 @@ ipcMain.handle("set-provider-model", async (event, provider, model) => {
   }
 });
 
+// Get custom base URL for specific provider
+ipcMain.handle("get-provider-base-url", async (event, provider) => {
+  try {
+    if (!VALID_PROVIDERS.includes(provider)) {
+      console.error(`Invalid provider: ${provider}`);
+      return "";
+    }
+
+    const config = readConfig();
+    return config.providers?.[provider]?.baseUrl || "";
+  } catch (error) {
+    console.error(`Error reading base URL for ${provider}:`, error);
+    return "";
+  }
+});
+
+// Set custom base URL for specific provider
+ipcMain.handle("set-provider-base-url", async (event, provider, baseUrl) => {
+  try {
+    if (!VALID_PROVIDERS.includes(provider)) {
+      return { success: false, error: `Invalid provider: ${provider}` };
+    }
+
+    const trimmed = (baseUrl || "").trim();
+    if (trimmed && !/^https?:\/\//i.test(trimmed)) {
+      return {
+        success: false,
+        error: "Base URL must start with http:// or https://",
+      };
+    }
+
+    const config = readConfig();
+    if (!config.providers) {
+      config.providers = {};
+    }
+    if (!config.providers[provider]) {
+      config.providers[provider] = { apiKey: "", encrypted: false };
+    }
+
+    config.providers[provider].baseUrl = trimmed;
+
+    saveConfig(config);
+    return { success: true };
+  } catch (error) {
+    console.error(`Error saving base URL for ${provider}:`, error);
+    return { success: false, error: error.message };
+  }
+});
+
+// Restart the Go backend so updated provider config (API keys, base URLs)
+// takes effect. Settings are injected as env vars at spawn time.
+ipcMain.handle("restart-backend", async () => {
+  try {
+    if (
+      process.env.EXTERNAL_BACKEND === "true" ||
+      process.env.SKIP_BACKEND_LAUNCH === "true"
+    ) {
+      return {
+        success: false,
+        error:
+          "Backend is externally managed (EXTERNAL_BACKEND); restart it manually.",
+      };
+    }
+
+    await restartGoBinary();
+    const ready = await waitForBackend(30, 500);
+    if (!ready) {
+      return {
+        success: false,
+        error: "Backend failed to become ready after restart",
+      };
+    }
+    return { success: true };
+  } catch (error) {
+    console.error("Error restarting backend:", error);
+    return { success: false, error: error.message };
+  }
+});
+
 // Get full providers config
 ipcMain.handle("get-providers-config", async () => {
   try {
     const config = readConfig();
     const activeProvider = config.activeProvider || "openai";
 
-    // Build response with hasApiKey (boolean) and model for each provider
+    // Build response with hasApiKey (boolean), model, and baseUrl for each provider
     const providers = {};
     for (const provider of VALID_PROVIDERS) {
       const providerConfig = config.providers?.[provider] || {};
@@ -1300,6 +1461,7 @@ ipcMain.handle("get-providers-config", async () => {
           providerConfig.apiKey && providerConfig.apiKey.length > 0
         ),
         model: providerConfig.model || "",
+        baseUrl: providerConfig.baseUrl || "",
       };
     }
 
@@ -1312,10 +1474,10 @@ ipcMain.handle("get-providers-config", async () => {
     return {
       activeProvider: "openai",
       providers: {
-        openai: { hasApiKey: false, model: "" },
-        anthropic: { hasApiKey: false, model: "" },
-        gemini: { hasApiKey: false, model: "" },
-        mistral: { hasApiKey: false, model: "" },
+        openai: { hasApiKey: false, model: "", baseUrl: "" },
+        anthropic: { hasApiKey: false, model: "", baseUrl: "" },
+        gemini: { hasApiKey: false, model: "", baseUrl: "" },
+        mistral: { hasApiKey: false, model: "", baseUrl: "" },
       },
     };
   }

--- a/src/frontend/src/electron/electron-preload.js
+++ b/src/frontend/src/electron/electron-preload.js
@@ -49,7 +49,7 @@ contextBridge.exposeInMainWorld("electronAPI", {
     return await ipcRenderer.invoke("set-provider-model", provider, model);
   },
 
-  // Get custom base URL for a specific provider (e.g. for OpenAI-compatible endpoints)
+  // Get custom base URL for a specific provider (e.g. for OpenAI-compatible custom endpoints)
   getProviderBaseUrl: async (provider) => {
     return await ipcRenderer.invoke("get-provider-base-url", provider);
   },

--- a/src/frontend/src/electron/electron-preload.js
+++ b/src/frontend/src/electron/electron-preload.js
@@ -49,9 +49,24 @@ contextBridge.exposeInMainWorld("electronAPI", {
     return await ipcRenderer.invoke("set-provider-model", provider, model);
   },
 
-  // Get full providers config (hasApiKey and model for each provider)
+  // Get custom base URL for a specific provider (e.g. for OpenAI-compatible endpoints)
+  getProviderBaseUrl: async (provider) => {
+    return await ipcRenderer.invoke("get-provider-base-url", provider);
+  },
+
+  // Set custom base URL for a specific provider
+  setProviderBaseUrl: async (provider, baseUrl) => {
+    return await ipcRenderer.invoke("set-provider-base-url", provider, baseUrl);
+  },
+
+  // Get full providers config (hasApiKey, model, baseUrl for each provider)
   getProvidersConfig: async () => {
     return await ipcRenderer.invoke("get-providers-config");
+  },
+
+  // Restart the Go backend so updated provider config takes effect
+  restartBackend: async () => {
+    return await ipcRenderer.invoke("restart-backend");
   },
 
   // Platform information

--- a/src/frontend/src/electron/electron.d.ts
+++ b/src/frontend/src/electron/electron.d.ts
@@ -6,6 +6,7 @@ type ProviderType = "openai" | "anthropic" | "gemini" | "mistral";
 interface ProviderSettings {
   hasApiKey: boolean;
   model: string; // Custom model or empty string for default
+  baseUrl?: string; // Custom endpoint URL (currently only used by OpenAI for OpenAI-compatible APIs)
 }
 
 interface ProvidersConfig {
@@ -33,7 +34,13 @@ interface ElectronAPI {
     provider: ProviderType,
     model: string
   ) => Promise<{ success: boolean; error?: string }>;
+  getProviderBaseUrl: (provider: ProviderType) => Promise<string>;
+  setProviderBaseUrl: (
+    provider: ProviderType,
+    baseUrl: string
+  ) => Promise<{ success: boolean; error?: string }>;
   getProvidersConfig: () => Promise<ProvidersConfig>;
+  restartBackend: () => Promise<{ success: boolean; error?: string }>;
 
   // Other settings
   getCACertSetupDismissed: () => Promise<boolean>;

--- a/src/frontend/src/electron/electron.d.ts
+++ b/src/frontend/src/electron/electron.d.ts
@@ -1,12 +1,17 @@
 // TypeScript declarations for Electron API exposed via preload script
 
 // Provider types for multi-provider support
-type ProviderType = "openai" | "anthropic" | "gemini" | "mistral";
+type ProviderType =
+  | "openai"
+  | "anthropic"
+  | "gemini"
+  | "mistral"
+  | "custom";
 
 interface ProviderSettings {
   hasApiKey: boolean;
   model: string; // Custom model or empty string for default
-  baseUrl?: string; // Custom endpoint URL (currently only used by OpenAI for OpenAI-compatible APIs)
+  baseUrl?: string; // Custom endpoint URL for OpenAI-compatible custom providers
 }
 
 interface ProvidersConfig {

--- a/src/frontend/src/hooks/useElectronSettings.ts
+++ b/src/frontend/src/hooks/useElectronSettings.ts
@@ -18,6 +18,7 @@ export function useElectronSettings(callbacks: ModalCallbacks) {
       anthropic: { hasApiKey: false, model: "" },
       gemini: { hasApiKey: false, model: "" },
       mistral: { hasApiKey: false, model: "" },
+      custom: { hasApiKey: false, model: "", baseUrl: "" },
     },
   });
   const [apiKey, setApiKey] = useState<string | null>(null);

--- a/src/frontend/src/types/provider.ts
+++ b/src/frontend/src/types/provider.ts
@@ -1,10 +1,16 @@
 // Provider types shared across the application
 
-export type ProviderType = "openai" | "anthropic" | "gemini" | "mistral";
+export type ProviderType =
+  | "openai"
+  | "anthropic"
+  | "gemini"
+  | "mistral"
+  | "custom";
 
 export interface ProviderSettings {
   hasApiKey: boolean;
   model: string;
+  baseUrl?: string;
 }
 
 export interface ProvidersConfig {
@@ -18,6 +24,7 @@ export const DEFAULT_MODELS: Record<ProviderType, string> = {
   anthropic: "claude-haiku-4-5",
   gemini: "gemini-flash-latest",
   mistral: "mistral-small-latest",
+  custom: "",
 };
 
 // Provider display names
@@ -26,6 +33,7 @@ export const PROVIDER_NAMES: Record<ProviderType, string> = {
   anthropic: "Anthropic",
   gemini: "Gemini",
   mistral: "Mistral",
+  custom: "Custom Provider",
 };
 
 export interface ContentBlock {

--- a/src/frontend/src/utils/providerHelpers.ts
+++ b/src/frontend/src/utils/providerHelpers.ts
@@ -28,6 +28,9 @@ export function apiUrl(path: string, isElectron: boolean): string {
 }
 
 export function getModel(provider: ProviderType, customModel: string): string {
+  if (provider === "custom") {
+    return customModel;
+  }
   return customModel || DEFAULT_MODELS[provider] || "gpt-4o-mini";
 }
 
@@ -41,6 +44,7 @@ export function buildRequestBody(
   switch (provider) {
     case "openai":
     case "mistral":
+    case "custom":
       return {
         ...baseFields,
         model,
@@ -90,7 +94,7 @@ export function buildHeaders(
     case "gemini":
       headers["x-goog-api-key"] = providerApiKey;
       break;
-    default: // openai, mistral
+    default: // openai, mistral, custom
       headers["Authorization"] = `Bearer ${providerApiKey}`;
   }
 
@@ -104,6 +108,7 @@ export function getProviderEndpoint(
   switch (provider) {
     case "openai":
     case "mistral":
+    case "custom":
       return "/v1/chat/completions";
     case "anthropic":
       return "/v1/messages";
@@ -122,6 +127,7 @@ export function extractAssistantMessage(
     switch (provider) {
       case "openai":
       case "mistral":
+      case "custom":
         return data.choices?.[0]?.message?.content || "";
 
       case "anthropic":


### PR DESCRIPTION
## Summary
- Adds a **Custom Endpoint URL** field to the OpenAI section of the Settings modal so users can point at OpenAI-compatible servers (LM Studio, Ollama, vLLM, Together, etc.). Validated to require an `http(s)://` scheme and persisted in the existing Electron config alongside `model` and the encrypted API key.
- Wires the persisted provider config (API keys + base URLs for all providers) into the Go backend by injecting them as the env vars `loadApplicationConfig` already understands (`OPENAI_API_KEY`, `OPENAI_BASE_URL`, …) when the Go binary is spawned.
- Adds a `restart-backend` IPC + a `stopGoBinaryAsync` / `restartGoBinary` pair, and the modal calls it after a successful save so changes apply without restarting the whole app.

## Test plan
- [x] Open Settings → OpenAI: enter `https://api.openai.com/v1` (or an LM Studio/Ollama URL) and a key, save, verify the success message and that requests now hit the configured endpoint.
- [x] Save with an invalid URL (no scheme) → expect a validation error from the IPC handler.
- [x] Save with `EXTERNAL_BACKEND=true` → expect the "externally managed" error from `restart-backend`.
- [x] Confirm previously-saved API keys still work after the restart path is exercised.

## User Interface
<img width="561" height="1017" alt="Screenshot 2026-04-29 at 7 57 47 PM" src="https://github.com/user-attachments/assets/83e53197-28be-4529-bf49-249593d1da6b" />
<img width="1326" height="832" alt="Screenshot 2026-04-29 at 7 57 25 PM" src="https://github.com/user-attachments/assets/77e3dcf7-0b3a-4361-b5fb-460ef0cba2f4" />

