### PR TITLE
fix: hardcode onnxruntime to 1.24.2

### DIFF
--- a/docs/02-development-guide.md
+++ b/docs/02-development-guide.md
@@ -100,11 +100,11 @@ python3 -m venv .venv
 source .venv/bin/activate
 
 # Install ONNX Runtime
-uv pip install "onnxruntime==1.25.0"
+uv pip install "onnxruntime==1.24.2"
 
 # Find and copy library (macOS)
 LIB_PATH=$(find .venv -name "libonnxruntime*.dylib" | head -1)
-cp "$LIB_PATH" ./build/libonnxruntime.1.25.0.dylib
+cp "$LIB_PATH" ./build/libonnxruntime.1.24.2.dylib
 
 # Find and copy library (Linux)
 LIB_PATH=$(find .venv -name "libonnxruntime.so.*" | head -1)
@@ -120,11 +120,11 @@ curl -LsSf https://astral.sh/uv/install.sh | sh
 # Create venv and install
 uv venv --python 3.13
 source .venv/bin/activate
-uv pip install "onnxruntime==1.25.0"
+uv pip install "onnxruntime==1.24.2"
 
 # Copy library (macOS)
 LIB_PATH=$(find .venv -name "libonnxruntime*.dylib" | head -1)
-cp "$LIB_PATH" ./build/libonnxruntime.1.25.0.dylib
+cp "$LIB_PATH" ./build/libonnxruntime.1.24.2.dylib
 
 # Copy library (Linux)
 LIB_PATH=$(find .venv -name "libonnxruntime.so.*" | head -1)
@@ -135,24 +135,24 @@ cp "$LIB_PATH" ./build/libonnxruntime.so
 
 ```bash
 # macOS ARM64 (Apple Silicon)
-wget https://github.com/microsoft/onnxruntime/releases/download/v1.25.0/onnxruntime-osx-arm64-1.25.0.tgz
-tar -xzf onnxruntime-osx-arm64-1.25.0.tgz
-cp onnxruntime-osx-arm64-1.25.0/lib/libonnxruntime.1.25.0.dylib build/
+wget https://github.com/microsoft/onnxruntime/releases/download/v1.24.2/onnxruntime-osx-arm64-1.24.2.tgz
+tar -xzf onnxruntime-osx-arm64-1.24.2.tgz
+cp onnxruntime-osx-arm64-1.24.2/lib/libonnxruntime.1.24.2.dylib build/
 
 # Linux
-wget https://github.com/microsoft/onnxruntime/releases/download/v1.25.0/onnxruntime-linux-x64-1.25.0.tgz
-tar -xzf onnxruntime-linux-x64-1.25.0.tgz
-cp onnxruntime-linux-x64-1.25.0/lib/libonnxruntime.so.1.25.0 build/libonnxruntime.so
+wget https://github.com/microsoft/onnxruntime/releases/download/v1.24.2/onnxruntime-linux-x64-1.24.2.tgz
+tar -xzf onnxruntime-linux-x64-1.24.2.tgz
+cp onnxruntime-linux-x64-1.24.2/lib/libonnxruntime.so.1.24.2 build/libonnxruntime.so
 ```
 
 **Verify:**
 ```bash
 ls -lh build/libonnxruntime.*
-# macOS: Should show libonnxruntime.1.25.0.dylib (~26MB)
+# macOS: Should show libonnxruntime.1.24.2.dylib (~26MB)
 # Linux: Should show libonnxruntime.so (~24MB)
 ```
 
-> **About ONNX Runtime:** the library uses a specific version for C API headers (right now it's 1.25.0). So we updated to 1.25.0 in the instructions, but it might evolve later when you read this. Please check the [ONNX Runtime pkg go](https://pkg.go.dev/github.com/yalue/onnxruntime_go#section-readme:~:text=At%20the%20time,be%20fairly%20easy%3A) and for context the [PR discussion about updating ONNX Runtime](https://github.com/dataiku/kiji-proxy/pull/364/changes/BASE..e21c6701583a5f6eb617d852441f7ca5add7e381#r3163645922)
+> **About ONNX Runtime:** the library uses a specific version for C API headers (right now it's 1.24.2). So we updated to 1.24.2 in the instructions, but it might evolve later when you read this. Please check the [ONNX Runtime pkg go](https://pkg.go.dev/github.com/yalue/onnxruntime_go#section-readme:~:text=At%20the%20time,be%20fairly%20easy%3A) and for context the [PR discussion about updating ONNX Runtime](https://github.com/dataiku/kiji-proxy/pull/364/changes/BASE..e21c6701583a5f6eb617d852441f7ca5add7e381#r3163645922)
 
 ### Compiling Tokenizers
 
@@ -708,7 +708,7 @@ ls -lh build/tokenizers/libtokenizers.a
 
 ```bash
 # macOS
-export ONNXRUNTIME_SHARED_LIBRARY_PATH="./build/libonnxruntime.1.25.0.dylib"
+export ONNXRUNTIME_SHARED_LIBRARY_PATH="./build/libonnxruntime.1.24.2.dylib"
 
 # Linux
 export LD_LIBRARY_PATH="./build:$LD_LIBRARY_PATH"

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.25.0
 
 require (
 	github.com/daulet/tokenizers v1.27.0
-	github.com/yalue/onnxruntime_go v1.28.0
+	github.com/yalue/onnxruntime_go v1.27.0
 	modernc.org/sqlite v1.50.0
 )
 

--- a/go.sum
+++ b/go.sum
@@ -32,6 +32,8 @@ github.com/remyoudompheng/bigfft v0.0.0-20230129092748-24d4a6f8daec h1:W09IVJc94
 github.com/remyoudompheng/bigfft v0.0.0-20230129092748-24d4a6f8daec/go.mod h1:qqbHyh8v60DhA7CoWK5oRCqLrMHRGoxYCSS9EjAz6Eo=
 github.com/stretchr/testify v1.8.4 h1:CcVxjf3Q8PM0mHUKJCdn+eZZtm5yQwehR5yeSVQQcUk=
 github.com/stretchr/testify v1.8.4/go.mod h1:sz/lmYIOXD/1dqDmKjjqLyZ2RngseejIcXlSw2iwfAo=
+github.com/yalue/onnxruntime_go v1.27.0 h1:c1YSgDNtpf0WGtxj3YeRIb8VC5LmM1J+Ve3uHdteC1U=
+github.com/yalue/onnxruntime_go v1.27.0/go.mod h1:b4X26A8pekNb1ACJ58wAXgNKeUCGEAQ9dmACut9Sm/4=
 github.com/yalue/onnxruntime_go v1.28.0 h1:ximEqgLtBhb3DY0IHyR0GWGpGJ+xef85qxgPwa/iotg=
 github.com/yalue/onnxruntime_go v1.28.0/go.mod h1:b4X26A8pekNb1ACJ58wAXgNKeUCGEAQ9dmACut9Sm/4=
 go.uber.org/goleak v1.3.0 h1:2K3zAYmnTNqV73imy9J1T3WC+gmCePx2hEGkimedGto=

--- a/src/backend/config/config.development.json
+++ b/src/backend/config/config.development.json
@@ -26,7 +26,7 @@
     "LogPIIChanges": true,
     "LogVerbose": true
   },
-  "ModelVariant": "trained",
+  "ModelVariant": "quantized",
   "UIPath": "src/frontend/dist",
   "Proxy": {
     "transparent_enabled": true,

--- a/src/backend/config/config.development.json
+++ b/src/backend/config/config.development.json
@@ -26,7 +26,7 @@
     "LogPIIChanges": true,
     "LogVerbose": true
   },
-  "ModelVariant": "quantized",
+  "ModelVariant": "trained",
   "UIPath": "src/frontend/dist",
   "Proxy": {
     "transparent_enabled": true,


### PR DESCRIPTION
## Summary
- Roll back ONNX Runtime to `1.24.2` and pin `onnxruntime_go` to `v1.27.0`. The previous bump assumed multiple ONNX Runtime versions could be supported; in practice the C API headers in `onnxruntime_go` require a specific matching runtime version, so we're hardcoding a single version for now.
- Update `docs/02-development-guide.md` so all install/download/verify steps reference `1.24.2`.

## Follow-up
- A separate issue will be created to revisit the ONNX Runtime versioning strategy and establish a single source of truth (e.g. a build constant / Makefile variable) so the Go module version, the downloaded shared library, and the docs cannot drift apart again.

## Test plan
- [x] `go build ./...` succeeds with the pinned `onnxruntime_go v1.27.0`
- [x] Backend starts locally with `libonnxruntime.1.24.2.dylib` / `libonnxruntime.so` 
- [x] Inference smoke test against the quantized model returns expected results