### PR TITLE
fix(ci): force electron-builder to sign on merged release PRs

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -178,6 +178,16 @@ jobs:
           APPLE_API_KEY: ${{ runner.temp }}/apple/AuthKey.p8
           APPLE_API_KEY_ID: ${{ secrets.APPLE_API_KEY_ID }}
           APPLE_API_ISSUER: ${{ secrets.APPLE_API_ISSUER }}
+          # Force signing on `pull_request` event runs (notably the merged
+          # release-PR path: this workflow's trigger includes merged PRs with
+          # the `release` label, and on those runs GITHUB_BASE_REF is set so
+          # electron-builder treats it as a PR build and silently skips
+          # signing — producing a half-signed bundle that fails
+          # `codesign --verify` with "code has no resources but signature
+          # indicates they must be present". Safe here: the job uses the
+          # protected "DMG Build Environment", gated on maintainer approval
+          # before secrets are exposed.
+          CSC_FOR_PULL_REQUEST: "true"
 
       - name: Normalize macOS Artifact Names
         run: |

--- a/src/scripts/build_dmg.sh
+++ b/src/scripts/build_dmg.sh
@@ -526,11 +526,34 @@ else
         exit 1
     fi
 
-    npx electron-builder --publish never
-    if [ $? -ne 0 ]; then
+    # Tee output so we can grep for the silent-skip-signing message below.
+    # electron-builder prints this when it detects a PR context (GITHUB_BASE_REF
+    # set) and CSC_FOR_PULL_REQUEST is not "true". The build keeps going but
+    # produces a half-signed bundle that fails `codesign --verify` later with
+    # "code has no resources but signature indicates they must be present".
+    EB_LOG="$(mktemp -t electron-builder.XXXXXX)"
+    trap 'rm -f "$EB_LOG"' RETURN EXIT
+    set +e
+    npx electron-builder --publish never 2>&1 | tee "$EB_LOG"
+    EB_STATUS=${PIPESTATUS[0]}
+    set -e
+    if [ "$EB_STATUS" -ne 0 ]; then
         echo "❌ electron-builder packaging failed!"
         exit 1
     fi
+
+    # Fail-fast: detect the exact decision line that means signing was skipped.
+    # Match must be exact — electron-builder also prints a general "security
+    # concerns" warning even when CSC_FOR_PULL_REQUEST=true, so a broad grep
+    # would false-positive. See app-builder-lib/out/codeSign/macCodeSign.js.
+    if grep -qF "Current build is a part of pull request, code signing will be skipped." "$EB_LOG"; then
+        echo "❌ electron-builder silently skipped code signing (PR context detected)."
+        echo "   Set CSC_FOR_PULL_REQUEST=true on the Build DMG step, or dispatch"
+        echo "   the workflow from a non-PR branch. Aborting before verify to"
+        echo "   avoid producing a half-signed artifact."
+        exit 1
+    fi
+    # Cleanup handled by trap above.
 
     # electron-builder notarizes + staples the .app. Verify that actually
     # happened — silent-skip is the failure mode we're guarding against.


### PR DESCRIPTION
## Summary
- Set `CSC_FOR_PULL_REQUEST: "true"` on the macOS Build DMG step so electron-builder doesn't silently skip signing when the workflow runs on a `pull_request` event (notably the merged release-PR path).
- Add a fail-fast guard in `build_dmg.sh` that greps for the exact electron-builder skip line and aborts before `codesign --verify`, so this class of misconfiguration cannot silently ship a half-signed artifact.

## Root cause
`electron-builder` checks for `GITHUB_BASE_REF` (set by GitHub Actions on `pull_request` events) and skips macOS signing unless `CSC_FOR_PULL_REQUEST=true`. Source: `app-builder-lib/out/codeSign/macCodeSign.js` and `builder-util/out/util.js`. The release workflow triggers on merged PRs with the `release` label — that's a `pull_request` event, so signing was being skipped. The embedded framework `_CodeSignature` manifests still claimed sealed resources, producing:

```
release/mac-arm64/Kiji Privacy Proxy.app: code has no resources but signature indicates they must be present
```

## Safety
Signing only runs because the job uses the protected `DMG Build Environment`, which requires maintainer approval before secrets are exposed. Forks cannot trigger signing.

## Test plan
- [X] Dispatch \"Build and Release\" against this branch — expect signing to succeed, `codesign --verify --deep --strict` to pass, and notarization + stapling to complete.
- [X] Confirm the fail-fast guard never fires on a normal build (no `CSC_FOR_PULL_REQUEST` warning ⇒ no exit).
- [X] (Optional) Simulate the failure by unsetting `CSC_FOR_PULL_REQUEST` and re-dispatching from a PR-event run; expect the new guard to abort with a clear message instead of producing a half-signed bundle.