### PR TITLE
fix: update backend and docs to clarify config folder

### DIFF
--- a/docs/01-getting-started.md
+++ b/docs/01-getting-started.md
@@ -112,7 +112,9 @@ The standalone backend runs as a headless server. Configure via environment vari
 
 **Installing CA Certificate (Required for HTTPS):**
 
-The proxy uses a self-signed certificate for MITM interception. You must trust it:
+The proxy uses a self-signed certificate for MITM interception. You must trust it.
+
+The CA cert lives in the app data directory: `~/Library/Application Support/Kiji Privacy Proxy/certs/ca.crt`. The desktop app also exposes a "Reveal CA cert in Finder" button in **Settings** if you'd rather not type the path.
 
 ```bash
 # System-wide trust (recommended)
@@ -120,12 +122,12 @@ sudo security add-trusted-cert \
   -d \
   -r trustRoot \
   -k /Library/Keychains/System.keychain \
-  ~/.kiji-proxy/certs/ca.crt
+  "$HOME/Library/Application Support/Kiji Privacy Proxy/certs/ca.crt"
 ```
 
 Or use Keychain Access GUI:
 1. Open **Keychain Access**
-2. File → Import Items → Select `~/.kiji-proxy/certs/ca.crt`
+2. File → Import Items → Select `~/Library/Application Support/Kiji Privacy Proxy/certs/ca.crt`
 3. Double-click "Kiji Privacy Proxy CA" certificate
 4. Expand **Trust** → Set to **Always Trust**
 
@@ -319,6 +321,9 @@ export DB_ENABLED="false"
 # Transparent proxy settings
 export TRANSPARENT_PROXY_ENABLED="true"
 export TRANSPARENT_PROXY_PORT=":8081"
+# CA paths default to the app data dir for your OS:
+#   macOS: ~/Library/Application Support/Kiji Privacy Proxy/certs/
+#   Linux: ~/.kiji-proxy/certs/  (or $KIJI_DATA_PATH / $XDG_DATA_HOME/kiji-proxy)
 export TRANSPARENT_PROXY_CA_PATH="~/.kiji-proxy/certs/ca.crt"
 export TRANSPARENT_PROXY_KEY_PATH="~/.kiji-proxy/certs/ca.key"
 ```
@@ -369,6 +374,8 @@ export TRANSPARENT_PROXY_KEY_PATH="~/.kiji-proxy/certs/ca.key"
   }
 }
 ```
+
+> **Path note:** Leading `~` is expanded to the user's home directory. On macOS the app's default CA paths are under `~/Library/Application Support/Kiji Privacy Proxy/certs/`; on Linux they default to `~/.kiji-proxy/certs/` (or `$KIJI_DATA_PATH` / `$XDG_DATA_HOME/kiji-proxy/certs/`). Override with absolute paths if you want them somewhere else.
 
 **Provider Configuration Notes:**
 

--- a/docs/05-advanced-topics.md
+++ b/docs/05-advanced-topics.md
@@ -49,7 +49,9 @@ Client ──[TLS]──> Kiji Privacy Proxy ──[TLS]──> api.openai.com
 **1. Root CA Certificate**
 - **Purpose:** Signs all leaf certificates
 - **Validity:** 10 years
-- **Location:** `~/.kiji-proxy/certs/ca.crt`
+- **Location:**
+  - macOS: `~/Library/Application Support/Kiji Privacy Proxy/certs/ca.crt`
+  - Linux: `~/.kiji-proxy/certs/ca.crt` (or `$KIJI_DATA_PATH` / `$XDG_DATA_HOME/kiji-proxy/certs/ca.crt`)
 - **Common Name:** "Kiji Privacy Proxy CA"
 - **Key Type:** RSA 2048-bit
 
@@ -70,7 +72,7 @@ sudo security add-trusted-cert \
   -d \
   -r trustRoot \
   -k /Library/Keychains/System.keychain \
-  ~/.kiji-proxy/certs/ca.crt
+  "$HOME/Library/Application Support/Kiji Privacy Proxy/certs/ca.crt"
 ```
 
 **macOS - User Keychain:**
@@ -80,14 +82,14 @@ sudo security add-trusted-cert \
 security add-trusted-cert \
   -r trustRoot \
   -k ~/Library/Keychains/login.keychain \
-  ~/.kiji-proxy/certs/ca.crt
+  "$HOME/Library/Application Support/Kiji Privacy Proxy/certs/ca.crt"
 ```
 
 **macOS - Keychain Access GUI:**
 
 1. Open **Keychain Access**
 2. File → Import Items
-3. Select `~/.kiji-proxy/certs/ca.crt`
+3. Select `~/Library/Application Support/Kiji Privacy Proxy/certs/ca.crt` (the desktop app's **Settings → Reveal CA cert in Finder** opens this folder for you)
 4. Double-click "Kiji Privacy Proxy CA"
 5. Trust → **Always Trust**
 6. Close (enter password)
@@ -141,6 +143,10 @@ export REQUESTS_CA_BUNDLE=/etc/ssl/certs/ca-certificates.crt
 
 **Node.js:**
 ```bash
+# macOS
+export NODE_EXTRA_CA_CERTS="$HOME/Library/Application Support/Kiji Privacy Proxy/certs/ca.crt"
+
+# Linux
 export NODE_EXTRA_CA_CERTS=~/.kiji-proxy/certs/ca.crt
 ```
 

--- a/src/backend/main.go
+++ b/src/backend/main.go
@@ -88,6 +88,7 @@ func run(configPath *string) error {
 		loadConfigFromFile(*configPath, cfg)
 	}
 	loadConfigFromEnv(cfg)
+	expandConfigPaths(cfg)
 
 	if err := cfg.ValidateConfig(); err != nil {
 		return err
@@ -173,6 +174,20 @@ func loadConfigFromFile(path string, cfg *config.Config) {
 	if err := decoder.Decode(cfg); err != nil {
 		log.Printf("Failed to decode config file: %v", err)
 	}
+}
+
+// expandConfigPaths normalizes all path-bearing fields on the config in place,
+// expanding a leading ~ to the user's home directory. Go's os.MkdirAll /
+// os.WriteFile do not expand ~ themselves, so without this any "~/..." value
+// loaded from JSON or env would be created as a literal "~/" folder in CWD.
+func expandConfigPaths(cfg *config.Config) {
+	cfg.ONNXModelPath = expandPath(cfg.ONNXModelPath)
+	cfg.TokenizerPath = expandPath(cfg.TokenizerPath)
+	cfg.ONNXModelDirectory = expandPath(cfg.ONNXModelDirectory)
+	cfg.UIPath = expandPath(cfg.UIPath)
+	cfg.Database.Path = expandPath(cfg.Database.Path)
+	cfg.Proxy.CAPath = expandPath(cfg.Proxy.CAPath)
+	cfg.Proxy.KeyPath = expandPath(cfg.Proxy.KeyPath)
 }
 
 // loadConfigFromEnv loads configuration from environment variables
@@ -304,10 +319,6 @@ func loadProxyConfig(cfg *config.Config) {
 	if keyPath := os.Getenv("TRANSPARENT_PROXY_KEY_PATH"); keyPath != "" {
 		cfg.Proxy.KeyPath = expandPath(keyPath)
 	}
-
-	// Also expand paths if they weren't set from environment
-	cfg.Proxy.CAPath = expandPath(cfg.Proxy.CAPath)
-	cfg.Proxy.KeyPath = expandPath(cfg.Proxy.KeyPath)
 }
 
 // expandPath expands ~ to the user's home directory

--- a/src/backend/main_test.go
+++ b/src/backend/main_test.go
@@ -1,0 +1,85 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/hannes/kiji-private/src/backend/config"
+)
+
+func TestExpandPath(t *testing.T) {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		t.Fatalf("UserHomeDir failed: %v", err)
+	}
+
+	tests := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{name: "empty", in: "", want: ""},
+		{name: "no tilde", in: "/etc/foo", want: "/etc/foo"},
+		{name: "bare tilde", in: "~", want: home},
+		{name: "tilde slash", in: "~/foo/bar", want: filepath.Join(home, "foo/bar")},
+		{name: "tilde without slash is literal", in: "~user/foo", want: "~user/foo"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := expandPath(tt.in); got != tt.want {
+				t.Errorf("expandPath(%q) = %q, want %q", tt.in, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestExpandConfigPaths(t *testing.T) {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		t.Fatalf("UserHomeDir failed: %v", err)
+	}
+
+	cfg := &config.Config{
+		ONNXModelPath:      "~/models/m.onnx",
+		TokenizerPath:      "~/models/tok.json",
+		ONNXModelDirectory: "~/models",
+		UIPath:             "./src/frontend/dist",
+		Database: config.DatabaseConfig{
+			Path: "~/.kiji/db.sqlite",
+		},
+		Proxy: config.ProxyConfig{
+			CAPath:  "~/Library/Application Support/Kiji Privacy Proxy/certs/ca.crt",
+			KeyPath: "/absolute/keys/ca.key",
+		},
+	}
+
+	expandConfigPaths(cfg)
+
+	want := map[string]string{
+		"ONNXModelPath":      filepath.Join(home, "models/m.onnx"),
+		"TokenizerPath":      filepath.Join(home, "models/tok.json"),
+		"ONNXModelDirectory": filepath.Join(home, "models"),
+		"UIPath":             "./src/frontend/dist",
+		"Database.Path":      filepath.Join(home, ".kiji/db.sqlite"),
+		"Proxy.CAPath":       filepath.Join(home, "Library/Application Support/Kiji Privacy Proxy/certs/ca.crt"),
+		"Proxy.KeyPath":      "/absolute/keys/ca.key",
+	}
+
+	got := map[string]string{
+		"ONNXModelPath":      cfg.ONNXModelPath,
+		"TokenizerPath":      cfg.TokenizerPath,
+		"ONNXModelDirectory": cfg.ONNXModelDirectory,
+		"UIPath":             cfg.UIPath,
+		"Database.Path":      cfg.Database.Path,
+		"Proxy.CAPath":       cfg.Proxy.CAPath,
+		"Proxy.KeyPath":      cfg.Proxy.KeyPath,
+	}
+
+	for field, wantVal := range want {
+		if got[field] != wantVal {
+			t.Errorf("%s = %q, want %q", field, got[field], wantVal)
+		}
+	}
+}

--- a/src/frontend/src/components/modals/CACertSetupModal.tsx
+++ b/src/frontend/src/components/modals/CACertSetupModal.tsx
@@ -1,5 +1,12 @@
 import { useState } from "react";
-import { X, ShieldCheck, Terminal, Globe, ExternalLink } from "lucide-react";
+import {
+  X,
+  ShieldCheck,
+  Terminal,
+  Globe,
+  ExternalLink,
+  FolderOpen,
+} from "lucide-react";
 import { isElectron } from "../../utils/providerHelpers";
 
 interface CACertSetupModalProps {
@@ -13,6 +20,7 @@ export default function CACertSetupModal({
 }: CACertSetupModalProps) {
   const [dontShowAgain, setDontShowAgain] = useState(false);
   const [currentTab, setCurrentTab] = useState<"system" | "browsers">("system");
+  const [revealError, setRevealError] = useState<string | null>(null);
 
   if (!isOpen) return null;
 
@@ -26,6 +34,18 @@ export default function CACertSetupModal({
       }
     }
     onClose();
+  };
+
+  const handleRevealCert = async () => {
+    setRevealError(null);
+    if (!isElectron || !window.electronAPI) {
+      setRevealError("Reveal in Finder is only available in the desktop app.");
+      return;
+    }
+    const result = await window.electronAPI.revealCACert();
+    if (!result.success) {
+      setRevealError(result.error || "Failed to open the certificate folder.");
+    }
   };
 
   return (
@@ -58,6 +78,22 @@ export default function CACertSetupModal({
               certificate on your system and/or browsers.
             </p>
           </div>
+
+          {/* Reveal in Finder shortcut */}
+          {isElectron && (
+            <div>
+              <button
+                onClick={handleRevealCert}
+                className="inline-flex items-center gap-2 px-4 py-2 bg-slate-100 hover:bg-slate-200 text-slate-800 rounded-lg text-sm font-medium transition-colors border border-slate-300"
+              >
+                <FolderOpen className="w-4 h-4" />
+                Reveal CA cert in Finder
+              </button>
+              {revealError && (
+                <p className="text-xs text-red-600 mt-2">{revealError}</p>
+              )}
+            </div>
+          )}
 
           {/* Tabs */}
           <div className="flex gap-2 border-b border-slate-200">

--- a/src/frontend/src/components/modals/SettingsModal.tsx
+++ b/src/frontend/src/components/modals/SettingsModal.tsx
@@ -14,6 +14,7 @@ import {
   Lock,
   Unlock,
   Globe,
+  FolderOpen,
 } from "lucide-react";
 
 // Providers that support a user-configurable custom endpoint URL.
@@ -640,6 +641,39 @@ export default function SettingsModal({
                 <ChevronRight className="w-5 h-5 text-slate-400" />
               </div>
             </div>
+
+            {/* Reveal CA cert in Finder */}
+            {isElectron && window.electronAPI && (
+              <div
+                onClick={async () => {
+                  const result = await window.electronAPI!.revealCACert();
+                  if (!result.success) {
+                    setMessage({
+                      type: "error",
+                      text:
+                        result.error ||
+                        "Failed to open the certificate folder.",
+                    });
+                  }
+                }}
+                className="border-2 border-slate-200 rounded-lg p-4 hover:border-slate-300 hover:bg-slate-50 transition-colors cursor-pointer"
+              >
+                <div className="flex items-center justify-between">
+                  <div className="flex items-center gap-3">
+                    <FolderOpen className="w-5 h-5 text-slate-600" />
+                    <div>
+                      <p className="font-medium text-slate-700">
+                        Reveal CA cert in Finder
+                      </p>
+                      <p className="text-xs text-slate-500">
+                        Open the folder containing the proxy's root certificate
+                      </p>
+                    </div>
+                  </div>
+                  <ChevronRight className="w-5 h-5 text-slate-400" />
+                </div>
+              </div>
+            )}
 
             {/* Message */}
             {message && (

--- a/src/frontend/src/electron/electron-main.js
+++ b/src/frontend/src/electron/electron-main.js
@@ -6,6 +6,7 @@ const {
   nativeImage,
   ipcMain,
   safeStorage,
+  shell,
 } = require("electron");
 const path = require("path");
 const fs = require("fs");
@@ -1444,6 +1445,32 @@ ipcMain.handle("restart-backend", async () => {
     return { success: true };
   } catch (error) {
     console.error("Error restarting backend:", error);
+    return { success: false, error: error.message };
+  }
+});
+
+// Open the CA cert location in the OS file manager. The Go backend writes the
+// CA to <userData>/certs/ca.crt — same path Electron knows via app.getPath().
+// If the file exists, highlight it; otherwise open the parent directory so the
+// user isn't left staring at an error dialog when the proxy hasn't generated
+// the cert yet.
+ipcMain.handle("reveal-ca-cert", async () => {
+  try {
+    const certPath = path.join(app.getPath("userData"), "certs", "ca.crt");
+    if (fs.existsSync(certPath)) {
+      shell.showItemInFolder(certPath);
+      return { success: true, path: certPath, exists: true };
+    }
+
+    const certDir = path.dirname(certPath);
+    fs.mkdirSync(certDir, { recursive: true });
+    const errMsg = await shell.openPath(certDir);
+    if (errMsg) {
+      return { success: false, error: errMsg };
+    }
+    return { success: true, path: certDir, exists: false };
+  } catch (error) {
+    console.error("Error revealing CA cert:", error);
     return { success: false, error: error.message };
   }
 });

--- a/src/frontend/src/electron/electron-preload.js
+++ b/src/frontend/src/electron/electron-preload.js
@@ -69,6 +69,11 @@ contextBridge.exposeInMainWorld("electronAPI", {
     return await ipcRenderer.invoke("restart-backend");
   },
 
+  // Open the CA cert location in the OS file manager (Finder on macOS)
+  revealCACert: async () => {
+    return await ipcRenderer.invoke("reveal-ca-cert");
+  },
+
   // Platform information
   platform: process.platform,
 

--- a/src/frontend/src/electron/electron.d.ts
+++ b/src/frontend/src/electron/electron.d.ts
@@ -46,6 +46,12 @@ interface ElectronAPI {
   ) => Promise<{ success: boolean; error?: string }>;
   getProvidersConfig: () => Promise<ProvidersConfig>;
   restartBackend: () => Promise<{ success: boolean; error?: string }>;
+  revealCACert: () => Promise<{
+    success: boolean;
+    path?: string;
+    exists?: boolean;
+    error?: string;
+  }>;
 
   // Other settings
   getCACertSetupDismissed: () => Promise<boolean>;


### PR DESCRIPTION
## Problem

A brand-new macOS user reported they couldn't find `~/.kiji-proxy/` to install the
CA cert, and that requests through the proxy were returning 403. Both symptoms
trace to the same root cause: the docs uniformly point at the **Linux** fallback
path (`~/.kiji-proxy/certs/ca.crt`), but on macOS the backend writes to
`~/Library/Application Support/Kiji Privacy Proxy/certs/ca.crt`. With nothing
imported into Keychain, the transparent proxy's MITM cert was untrusted and
upstream calls failed.

While digging in, I also noticed `loadConfigFromFile` doesn't expand `~` in path
fields. Go's `os.MkdirAll`/`os.WriteFile` treat `~` as a literal directory, so
anyone running with `--config src/backend/config/config.development.json` would
end up creating a literal `./~/Library/...` folder in their CWD instead of
writing to home.

## Changes

**Docs (`docs/01-getting-started.md`, `docs/05-advanced-topics.md`)**
- macOS instructions now use `~/Library/Application Support/Kiji Privacy Proxy/certs/ca.crt`.
- Linux instructions kept at `~/.kiji-proxy/certs/ca.crt`.
- Generic env-var/config-file examples annotate the per-OS default and call out
  `KIJI_DATA_PATH` / `XDG_DATA_HOME` overrides.

**Backend `~` expansion (`src/backend/main.go`, `+ main_test.go`)**
- New `expandConfigPaths(cfg)` normalizes every path-bearing field
  (`ONNXModelPath`, `TokenizerPath`, `ONNXModelDirectory`, `UIPath`,
  `Database.Path`, `Proxy.CAPath`, `Proxy.KeyPath`).
- Called once in `run()` after both `loadConfigFromFile` and `loadConfigFromEnv`,
  so JSON-loaded *and* env-loaded paths get the same treatment.
- Drops the now-redundant per-call expansions previously inlined in `loadProxyConfig`.
- Tests cover bare `~`, `~/...`, no-tilde, and `~user` (left literal).

**"Reveal CA cert in Finder" button**
- New `reveal-ca-cert` IPC in `electron-main.js`. Uses `shell.showItemInFolder`
  when the cert exists; falls back to `shell.openPath` on the parent directory
  (creating it first) so users aren't stuck if the proxy hasn't generated the
  cert yet.
- Surfaced in two places: the top of `CACertSetupModal` (so first-run users see
  it before the wall of trust-store instructions) and as a tile in
  `SettingsModal` (so it's discoverable later).

## Test plan
- [x] Rename `~/Library/Application Support/Kiji Privacy Proxy/` and relaunch
      the app. Verify CACertSetupModal appears and the Reveal button opens
      Finder at the (newly created) `certs/` folder before the backend has
      generated the cert.
- [x] After the backend regenerates `ca.crt`, click Reveal again — Finder
      should open with `ca.crt` highlighted.
- [x] Run dev backend with `--config src/backend/config/config.development.json`
      and confirm certs land under the real macOS path, not a literal `./~/`
      folder in CWD.
- [x] Open Settings → click the new "Reveal CA cert in Finder" tile.
- [x] `go test ./src/backend/...` (covers new `expandPath` / `expandConfigPaths`).
