### PR TITLE
fix: added kiji logo to package.json

### DIFF
--- a/src/frontend/package.json
+++ b/src/frontend/package.json
@@ -85,6 +85,7 @@
       "assets/icon.png",
       "assets/icon-16.png",
       "assets/arrow.png",
+      "assets/kiji_proxy.svg",
       "!**/pii_onnx_model/**/*",
       "!**/*.map",
       "!**/.DS_Store"


### PR DESCRIPTION
Due to the missing path, the logo wasn't visible in the dmg build app