### PR TITLE
feat: add PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,17 @@
+## Description
+
+<!-- Describe what this PR does and why. -->
+
+## Linked Issue
+
+Closes #
+
+## Testing Done
+
+<!-- Describe how you tested the changes. -->
+
+## Checklist
+
+- [ ] Tests pass locally
+- [ ] Code follows project style guidelines
+- [ ] Documentation updated if needed

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -6,12 +6,44 @@
 
 Closes #
 
+## Type of Change
+
+- [ ] Bug fix
+- [ ] New feature
+- [ ] Refactor / code quality
+- [ ] Documentation update
+- [ ] CI / build change
+
 ## Testing Done
 
-<!-- Describe how you tested the changes. -->
+<!-- Describe how you tested the changes. Include commands run and results observed. -->
+
+**Unit tests (Go):**
+```
+make test-go
+```
+
+**Unit tests (Python):**
+```
+make test
+```
+
+**Linting & type checks:**
+```
+make lint
+make typecheck
+```
+
+**Manual testing (if applicable):**
+- Describe the scenario tested (e.g. PII type detected, proxy request flow, Chrome extension behavior)
+- Include before/after behavior if fixing a bug
+- Note any edge cases verified (e.g. nested PII in JSON payloads, restoration accuracy)
 
 ## Checklist
 
-- [ ] Tests pass locally
-- [ ] Code follows project style guidelines
-- [ ] Documentation updated if needed
+- [ ] `make test-go` and `make test` pass locally
+- [ ] `make lint` reports no new errors
+- [ ] New PII detection changes are covered by unit tests in `tests/`
+- [ ] Go proxy changes include test coverage in `src/` or `model/`
+- [ ] Documentation updated if behavior or configuration changed
+- [ ] No sensitive data or credentials included


### PR DESCRIPTION
Closes #425

Adds `.github/PULL_REQUEST_TEMPLATE.md` with sections for description, linked issue, testing done, and a pre-submit checklist.