### PR TITLE
chore: add changeset and update docs for configurable PII types

### DIFF
--- a/.changeset/sweet-comics-sing.md
+++ b/.changeset/sweet-comics-sing.md
@@ -1,0 +1,11 @@
+---
+"kiji-privacy-proxy": minor
+---
+
+Configurable PII entity types and custom regex patterns
+
+- Chrome extension options page: enable/disable PII entity types per-request
+- Custom regex patterns: add/edit/remove user-defined regex rules with replacement text
+- New API endpoints: `GET /api/pii/labels`, `GET/POST /api/pii/patterns`, `PUT/DELETE /api/pii/patterns/{id}`
+- Backend `MaskText` accepts `enabled_labels` to filter which PII types are masked
+- Entity deduplication: overlapping spans resolved by length, custom regex wins ties

--- a/docs/06-chrome-extension.md
+++ b/docs/06-chrome-extension.md
@@ -73,6 +73,8 @@ All settings are accessible via the extension's options page (right-click extens
 
 - **Backend URL** — The Kiji Privacy Proxy server address (default: `http://localhost:8081`)
 - **Intercept domains** — URL match patterns where the extension is active (one per line)
+- **PII entity types** — Check or uncheck PII labels from the model to control which entity types get masked per-request. A "Disable all / Enable all" toggle is provided. Changes are persisted to `chrome.storage.sync` and sent as `enabled_labels` with each PII check.
+- **Custom patterns** — Add user-defined regex rules on top of the ML model. Each pattern has a label, regex, description, and optional replacement string. Patterns are persisted server-side in SQLite. A live preview field lets you test a regex against sample text before saving. Patterns can be edited or removed inline.
 
 Default domains:
 ```

--- a/docs/06-chrome-extension.md
+++ b/docs/06-chrome-extension.md
@@ -74,7 +74,7 @@ All settings are accessible via the extension's options page (right-click extens
 - **Backend URL** — The Kiji Privacy Proxy server address (default: `http://localhost:8081`)
 - **Intercept domains** — URL match patterns where the extension is active (one per line)
 - **PII entity types** — Check or uncheck PII labels from the model to control which entity types get masked per-request. A "Disable all / Enable all" toggle is provided. Changes are persisted to `chrome.storage.sync` and sent as `enabled_labels` with each PII check.
-- **Custom patterns** — Add user-defined regex rules on top of the ML model. Each pattern has a label, regex, description, and optional replacement string. Patterns are persisted server-side in SQLite. A live preview field lets you test a regex against sample text before saving. Patterns can be edited or removed inline.
+- **Custom patterns** — Add user-defined regex rules on top of the ML model. Each pattern has a label, regex, and optional replacement string. Patterns are persisted server-side in SQLite. A live preview field lets you test a regex against sample text before saving. Patterns can be edited or removed inline.
 
 Default domains:
 ```


### PR DESCRIPTION
Closes #458, Closes #459

Follow-up to #470 (main feature PR), adds the changeset and updates `docs/06-chrome-extension.md` to document the new PII entity types and custom patterns configuration options available in the extension settings.