### PR TITLE
fix: rewrote provider for openai, handling schema and response

### DIFF
--- a/src/backend/providers/openai.go
+++ b/src/backend/providers/openai.go
@@ -1,6 +1,7 @@
 package providers
 
 import (
+	"encoding/json"
 	"fmt"
 	"log"
 	"net/http"
@@ -10,11 +11,184 @@ import (
 )
 
 const (
-	ProviderTypeOpenAI      ProviderType = "openai"
-	ProviderSubpathOpenAI   string       = "/v1/chat/completions"
-	ProviderAPIDomainOpenAI string       = "api.openai.com"
-	ProviderNameOpenAI      string       = "OpenAI"
+	ProviderTypeOpenAI         ProviderType = "openai"
+	ProviderSubpathOpenAI      string       = "/v1/chat/completions"
+	ProviderSubpathOpenAIResp  string       = "/v1/responses"
+	ProviderAPIDomainOpenAI    string       = "api.openai.com"
+	ProviderNameOpenAI         string       = "OpenAI"
 )
+
+// isReasoningModel reports whether an OpenAI model name belongs to a reasoning
+// family that requires the Responses API. Covers gpt-5* and the o-series
+// (o1, o3, o4, …). Detection is intentionally string-based — OpenAI doesn't
+// expose a capability flag, and the proxy needs to route before it ever
+// reaches the model.
+func isReasoningModel(model string) bool {
+	if strings.HasPrefix(model, "gpt-5") {
+		return true
+	}
+	// o1, o1-mini, o3, o3-mini, o4-mini, etc.
+	if len(model) >= 2 && model[0] == 'o' && model[1] >= '1' && model[1] <= '9' {
+		return true
+	}
+	return false
+}
+
+// MaybeConvertOpenAIRequest reconciles the request body shape with the target
+// endpoint. Reasoning models on /v1/chat/completions are rewritten to the
+// Responses API; non-reasoning models on /v1/responses are rewritten to Chat
+// Completions. In all other cases the body and path are returned unchanged.
+//
+// This runs after PII masking, so any masked content in `messages` is carried
+// into `input`/`instructions` by the conversion.
+func MaybeConvertOpenAIRequest(body []byte, path string) ([]byte, string) {
+	var data map[string]interface{}
+	if err := json.Unmarshal(body, &data); err != nil {
+		return body, path
+	}
+
+	model, _ := data["model"].(string)
+	if model == "" {
+		return body, path
+	}
+
+	reasoning := isReasoningModel(model)
+
+	switch {
+	case reasoning && path == ProviderSubpathOpenAI && hasChatCompletionsShape(data):
+		converted := convertChatToResponses(data)
+		out, err := json.Marshal(converted)
+		if err != nil {
+			return body, path
+		}
+		return out, ProviderSubpathOpenAIResp
+
+	case !reasoning && path == ProviderSubpathOpenAIResp && hasResponsesShape(data):
+		converted := convertResponsesToChat(data)
+		out, err := json.Marshal(converted)
+		if err != nil {
+			return body, path
+		}
+		return out, ProviderSubpathOpenAI
+	}
+
+	return body, path
+}
+
+func hasChatCompletionsShape(data map[string]interface{}) bool {
+	_, ok := data["messages"]
+	return ok
+}
+
+func hasResponsesShape(data map[string]interface{}) bool {
+	if _, ok := data["input"]; ok {
+		return true
+	}
+	if _, ok := data["instructions"]; ok {
+		return true
+	}
+	return false
+}
+
+// convertChatToResponses rewrites a Chat-Completions payload as a Responses-API
+// payload. System/developer messages are merged into `instructions`; remaining
+// messages become `input`. `max_tokens` is renamed to `max_output_tokens`.
+// Parameters that the Responses API does not accept are dropped.
+func convertChatToResponses(data map[string]interface{}) map[string]interface{} {
+	out := make(map[string]interface{}, len(data))
+	for k, v := range data {
+		out[k] = v
+	}
+
+	if messages, ok := data["messages"].([]interface{}); ok {
+		var systemPrompts []string
+		input := make([]interface{}, 0, len(messages))
+		for _, msg := range messages {
+			msgMap, ok := msg.(map[string]interface{})
+			if !ok {
+				continue
+			}
+			role, _ := msgMap["role"].(string)
+			if role == "system" || role == "developer" {
+				if c, ok := msgMap["content"].(string); ok {
+					systemPrompts = append(systemPrompts, c)
+					continue
+				}
+			}
+			input = append(input, msgMap)
+		}
+		if len(systemPrompts) > 0 {
+			if existing, ok := out["instructions"].(string); ok && existing != "" {
+				out["instructions"] = existing + "\n\n" + strings.Join(systemPrompts, "\n\n")
+			} else {
+				out["instructions"] = strings.Join(systemPrompts, "\n\n")
+			}
+		}
+		out["input"] = input
+		delete(out, "messages")
+	}
+
+	if mt, ok := data["max_tokens"]; ok {
+		if _, exists := out["max_output_tokens"]; !exists {
+			out["max_output_tokens"] = mt
+		}
+		delete(out, "max_tokens")
+	}
+
+	// Strip Chat-Completions-only fields the Responses API rejects.
+	for _, k := range []string{"frequency_penalty", "presence_penalty", "logit_bias", "logprobs", "top_logprobs", "n", "stop"} {
+		delete(out, k)
+	}
+
+	return out
+}
+
+// convertResponsesToChat rewrites a Responses-API payload as a Chat-Completions
+// payload. `instructions` becomes a leading system message; `input` (string or
+// array) becomes the `messages` array. `max_output_tokens` is renamed to
+// `max_tokens`.
+func convertResponsesToChat(data map[string]interface{}) map[string]interface{} {
+	out := make(map[string]interface{}, len(data))
+	for k, v := range data {
+		out[k] = v
+	}
+
+	messages := []interface{}{}
+
+	if instructions, ok := data["instructions"].(string); ok && instructions != "" {
+		messages = append(messages, map[string]interface{}{
+			"role":    "system",
+			"content": instructions,
+		})
+	}
+	delete(out, "instructions")
+
+	switch input := data["input"].(type) {
+	case string:
+		messages = append(messages, map[string]interface{}{
+			"role":    "user",
+			"content": input,
+		})
+	case []interface{}:
+		messages = append(messages, input...)
+	}
+	delete(out, "input")
+
+	out["messages"] = messages
+
+	if mt, ok := data["max_output_tokens"]; ok {
+		if _, exists := out["max_tokens"]; !exists {
+			out["max_tokens"] = mt
+		}
+		delete(out, "max_output_tokens")
+	}
+
+	// Responses-API-only fields that have no Chat-Completions equivalent.
+	delete(out, "previous_response_id")
+	delete(out, "reasoning")
+
+	return out
+}
 
 type OpenAIProvider struct {
 	apiDomain         string
@@ -38,7 +212,43 @@ func (p *OpenAIProvider) GetBaseURL(useHttps bool) string {
 	return normalizeBaseURL(p.apiDomain, useHttps)
 }
 
+// isResponsesAPIRequest reports whether the payload is in OpenAI Responses-API
+// shape. Detection inspects payload fields directly so that the proxy does not
+// need a hard-coded list of reasoning-model names — the schema reflects the
+// endpoint the client is targeting.
+func isResponsesAPIRequest(data map[string]interface{}) bool {
+	if _, ok := data["messages"]; ok {
+		return false
+	}
+	if _, ok := data["input"]; ok {
+		return true
+	}
+	if _, ok := data["instructions"]; ok {
+		return true
+	}
+	return false
+}
+
+// isResponsesAPIResponse reports whether the payload is in OpenAI Responses-API
+// shape.
+func isResponsesAPIResponse(data map[string]interface{}) bool {
+	if _, ok := data["choices"]; ok {
+		return false
+	}
+	if _, ok := data["output"]; ok {
+		return true
+	}
+	if _, ok := data["output_text"]; ok {
+		return true
+	}
+	return false
+}
+
 func (p *OpenAIProvider) ExtractRequestText(data map[string]interface{}) (string, error) {
+	if isResponsesAPIRequest(data) {
+		return extractResponsesRequestText(data)
+	}
+
 	messages, ok := data["messages"].([]interface{})
 	if !ok {
 		return "", fmt.Errorf("no messages field in OpenAI request")
@@ -57,7 +267,53 @@ func (p *OpenAIProvider) ExtractRequestText(data map[string]interface{}) (string
 	return result.String(), nil
 }
 
+func extractResponsesRequestText(data map[string]interface{}) (string, error) {
+	var result strings.Builder
+
+	if instructions, ok := data["instructions"].(string); ok && instructions != "" {
+		result.WriteString(instructions + "\n")
+	}
+
+	switch input := data["input"].(type) {
+	case string:
+		if input != "" {
+			result.WriteString(input + "\n")
+		}
+	case []interface{}:
+		for _, item := range input {
+			itemMap, ok := item.(map[string]interface{})
+			if !ok {
+				continue
+			}
+			switch content := itemMap["content"].(type) {
+			case string:
+				result.WriteString(content + "\n")
+			case []interface{}:
+				for _, part := range content {
+					partMap, ok := part.(map[string]interface{})
+					if !ok {
+						continue
+					}
+					if text, ok := partMap["text"].(string); ok {
+						result.WriteString(text + "\n")
+					}
+				}
+			}
+		}
+	case nil:
+		// instructions-only requests are valid; fall through
+	default:
+		return "", fmt.Errorf("unexpected 'input' field type in OpenAI Responses-API request")
+	}
+
+	return result.String(), nil
+}
+
 func (p *OpenAIProvider) ExtractResponseText(data map[string]interface{}) (string, error) {
+	if isResponsesAPIResponse(data) {
+		return extractResponsesResponseText(data)
+	}
+
 	choices, ok := data["choices"].([]interface{})
 	if !ok || len(choices) == 0 {
 		return "", fmt.Errorf("no choices in OpenAI response")
@@ -79,7 +335,45 @@ func (p *OpenAIProvider) ExtractResponseText(data map[string]interface{}) (strin
 	return result.String(), nil
 }
 
+func extractResponsesResponseText(data map[string]interface{}) (string, error) {
+	if output, ok := data["output"].([]interface{}); ok && len(output) > 0 {
+		var result strings.Builder
+		for _, item := range output {
+			itemMap, ok := item.(map[string]interface{})
+			if !ok {
+				continue
+			}
+			contents, ok := itemMap["content"].([]interface{})
+			if !ok {
+				continue
+			}
+			for _, c := range contents {
+				cMap, ok := c.(map[string]interface{})
+				if !ok {
+					continue
+				}
+				if text, ok := cMap["text"].(string); ok {
+					result.WriteString(text + "\n")
+				}
+			}
+		}
+		if result.Len() > 0 {
+			return result.String(), nil
+		}
+	}
+
+	if outputText, ok := data["output_text"].(string); ok {
+		return outputText + "\n", nil
+	}
+
+	return "", fmt.Errorf("no output content in OpenAI Responses-API response")
+}
+
 func (p *OpenAIProvider) CreateMaskedRequest(maskedRequest map[string]interface{}, maskPIIInText maskPIIInTextType) (map[string]string, *[]pii.Entity, error) {
+	if isResponsesAPIRequest(maskedRequest) {
+		return createMaskedResponsesRequest(maskedRequest, maskPIIInText)
+	}
+
 	maskedToOriginal := make(map[string]string)
 	var entities []pii.Entity
 
@@ -112,8 +406,73 @@ func (p *OpenAIProvider) CreateMaskedRequest(maskedRequest map[string]interface{
 	return maskedToOriginal, &entities, nil
 }
 
+// createMaskedResponsesRequest walks the Responses-API request shape: a string
+// or array `input` field, plus an optional string `instructions` field.
+func createMaskedResponsesRequest(maskedRequest map[string]interface{}, maskPIIInText maskPIIInTextType) (map[string]string, *[]pii.Entity, error) {
+	maskedToOriginal := make(map[string]string)
+	var entities []pii.Entity
+
+	mergeMask := func(masked string, m map[string]string, ents []pii.Entity) {
+		entities = append(entities, ents...)
+		for k, v := range m {
+			maskedToOriginal[k] = v
+		}
+		_ = masked
+	}
+
+	if instructions, ok := maskedRequest["instructions"].(string); ok {
+		masked, m, ents := maskPIIInText(instructions, "[MaskedRequest]")
+		maskedRequest["instructions"] = masked
+		mergeMask(masked, m, ents)
+	}
+
+	switch input := maskedRequest["input"].(type) {
+	case string:
+		masked, m, ents := maskPIIInText(input, "[MaskedRequest]")
+		maskedRequest["input"] = masked
+		mergeMask(masked, m, ents)
+	case []interface{}:
+		for _, item := range input {
+			itemMap, ok := item.(map[string]interface{})
+			if !ok {
+				continue
+			}
+			switch content := itemMap["content"].(type) {
+			case string:
+				masked, m, ents := maskPIIInText(content, "[MaskedRequest]")
+				itemMap["content"] = masked
+				mergeMask(masked, m, ents)
+			case []interface{}:
+				for _, part := range content {
+					partMap, ok := part.(map[string]interface{})
+					if !ok {
+						continue
+					}
+					text, ok := partMap["text"].(string)
+					if !ok {
+						continue
+					}
+					masked, m, ents := maskPIIInText(text, "[MaskedRequest]")
+					partMap["text"] = masked
+					mergeMask(masked, m, ents)
+				}
+			}
+		}
+	case nil:
+		// instructions-only requests are valid
+	default:
+		return maskedToOriginal, &entities, fmt.Errorf("unexpected 'input' field type in OpenAI Responses-API request")
+	}
+
+	return maskedToOriginal, &entities, nil
+}
+
 //nolint:dupl
 func (p *OpenAIProvider) RestoreMaskedResponse(maskedResponse map[string]interface{}, maskedToOriginal map[string]string, interceptionNotice string, restorePII restorePIIType, getLogResponses getLogResponsesType, getLogVerbose getLogVerboseType, getAddProxyNotice getAddProxyNotice) error {
+	if isResponsesAPIResponse(maskedResponse) {
+		return restoreResponsesAPIResponse(maskedResponse, maskedToOriginal, interceptionNotice, restorePII, getLogResponses, getLogVerbose, getAddProxyNotice)
+	}
+
 	// Iterate over all 'choices' contained in 'maskedRequest' (as OpenAI can return more than one).
 	choices, ok := maskedResponse["choices"].([]interface{})
 	if !ok || len(choices) == 0 {
@@ -157,6 +516,83 @@ func (p *OpenAIProvider) RestoreMaskedResponse(maskedResponse map[string]interfa
 	}
 
 	return err
+}
+
+// restoreResponsesAPIResponse walks the Responses-API response shape:
+// `output[].content[].text` items plus the top-level `output_text` convenience
+// field. Returns an error only if neither field is present (i.e. nothing to
+// restore).
+func restoreResponsesAPIResponse(maskedResponse map[string]interface{}, maskedToOriginal map[string]string, interceptionNotice string, restorePII restorePIIType, getLogResponses getLogResponsesType, getLogVerbose getLogVerboseType, getAddProxyNotice getAddProxyNotice) error {
+	output, hasOutput := maskedResponse["output"].([]interface{})
+	outputText, hasOutputText := maskedResponse["output_text"].(string)
+
+	if !hasOutput && !hasOutputText {
+		return fmt.Errorf("no output or output_text in OpenAI Responses-API response")
+	}
+
+	addNotice := getAddProxyNotice()
+
+	if hasOutput {
+		// Track the last output_text-bearing content node so we can append the
+		// proxy notice exactly once per message item (mirroring the
+		// one-notice-per-choice behavior of the Chat Completions path).
+		for _, item := range output {
+			itemMap, ok := item.(map[string]interface{})
+			if !ok {
+				continue
+			}
+			contents, ok := itemMap["content"].([]interface{})
+			if !ok {
+				continue
+			}
+
+			var lastTextNode map[string]interface{}
+			for _, c := range contents {
+				cMap, ok := c.(map[string]interface{})
+				if !ok {
+					continue
+				}
+				text, ok := cMap["text"].(string)
+				if !ok {
+					continue
+				}
+				restored := restorePII(text, maskedToOriginal)
+				if restored != text && getLogResponses() {
+					log.Printf("PII restored in response content")
+					if getLogVerbose() {
+						log.Printf("Original response content: %s", text)
+						log.Printf("Restored response content: %s", restored)
+					}
+				}
+				cMap["text"] = restored
+				lastTextNode = cMap
+			}
+
+			itemType, _ := itemMap["type"].(string)
+			if addNotice && lastTextNode != nil && itemType == "message" {
+				if t, ok := lastTextNode["text"].(string); ok {
+					lastTextNode["text"] = t + interceptionNotice
+				}
+			}
+		}
+	}
+
+	if hasOutputText {
+		restored := restorePII(outputText, maskedToOriginal)
+		if restored != outputText && getLogResponses() {
+			log.Printf("PII restored in response output_text")
+			if getLogVerbose() {
+				log.Printf("Original output_text: %s", outputText)
+				log.Printf("Restored output_text: %s", restored)
+			}
+		}
+		if addNotice {
+			restored += interceptionNotice
+		}
+		maskedResponse["output_text"] = restored
+	}
+
+	return nil
 }
 
 func (p *OpenAIProvider) SetAuthHeaders(req *http.Request) {

--- a/src/backend/providers/openai.go
+++ b/src/backend/providers/openai.go
@@ -18,18 +18,31 @@ const (
 	ProviderNameOpenAI         string       = "OpenAI"
 )
 
+// reasoningModelFamilies lists OpenAI model family prefixes that require the
+// Responses API. A model matches if its name equals the prefix exactly or
+// starts with `<prefix>-` (e.g. "o1-mini", "gpt-5-2025-08-07"). Update this
+// list when OpenAI releases new reasoning families.
+var reasoningModelFamilies = []string{
+	"gpt-5",
+	"o1",
+	"o1-mini",
+	"o1-preview",
+	"o1-pro",
+	"o3",
+	"o3-mini",
+	"o3-pro",
+	"o4-mini",
+}
+
 // isReasoningModel reports whether an OpenAI model name belongs to a reasoning
-// family that requires the Responses API. Covers gpt-5* and the o-series
-// (o1, o3, o4, …). Detection is intentionally string-based — OpenAI doesn't
-// expose a capability flag, and the proxy needs to route before it ever
-// reaches the model.
+// family that requires the Responses API. Detection is string-based against
+// reasoningModelFamilies because OpenAI does not expose a capability flag and
+// the proxy needs to route before the request reaches the model.
 func isReasoningModel(model string) bool {
-	if strings.HasPrefix(model, "gpt-5") {
-		return true
-	}
-	// o1, o1-mini, o3, o3-mini, o4-mini, etc.
-	if len(model) >= 2 && model[0] == 'o' && model[1] >= '1' && model[1] <= '9' {
-		return true
+	for _, family := range reasoningModelFamilies {
+		if model == family || strings.HasPrefix(model, family+"-") {
+			return true
+		}
 	}
 	return false
 }

--- a/src/backend/providers/openai.go
+++ b/src/backend/providers/openai.go
@@ -25,12 +25,7 @@ const (
 var reasoningModelFamilies = []string{
 	"gpt-5",
 	"o1",
-	"o1-mini",
-	"o1-preview",
-	"o1-pro",
 	"o3",
-	"o3-mini",
-	"o3-pro",
 	"o4-mini",
 }
 
@@ -425,25 +420,24 @@ func createMaskedResponsesRequest(maskedRequest map[string]interface{}, maskPIII
 	maskedToOriginal := make(map[string]string)
 	var entities []pii.Entity
 
-	mergeMask := func(masked string, m map[string]string, ents []pii.Entity) {
+	mergeMask := func(m map[string]string, ents []pii.Entity) {
 		entities = append(entities, ents...)
 		for k, v := range m {
 			maskedToOriginal[k] = v
 		}
-		_ = masked
 	}
 
 	if instructions, ok := maskedRequest["instructions"].(string); ok {
 		masked, m, ents := maskPIIInText(instructions, "[MaskedRequest]")
 		maskedRequest["instructions"] = masked
-		mergeMask(masked, m, ents)
+		mergeMask(m, ents)
 	}
 
 	switch input := maskedRequest["input"].(type) {
 	case string:
 		masked, m, ents := maskPIIInText(input, "[MaskedRequest]")
 		maskedRequest["input"] = masked
-		mergeMask(masked, m, ents)
+		mergeMask(m, ents)
 	case []interface{}:
 		for _, item := range input {
 			itemMap, ok := item.(map[string]interface{})
@@ -454,7 +448,7 @@ func createMaskedResponsesRequest(maskedRequest map[string]interface{}, maskPIII
 			case string:
 				masked, m, ents := maskPIIInText(content, "[MaskedRequest]")
 				itemMap["content"] = masked
-				mergeMask(masked, m, ents)
+				mergeMask(m, ents)
 			case []interface{}:
 				for _, part := range content {
 					partMap, ok := part.(map[string]interface{})
@@ -467,7 +461,7 @@ func createMaskedResponsesRequest(maskedRequest map[string]interface{}, maskPIII
 					}
 					masked, m, ents := maskPIIInText(text, "[MaskedRequest]")
 					partMap["text"] = masked
-					mergeMask(masked, m, ents)
+					mergeMask(m, ents)
 				}
 			}
 		}

--- a/src/backend/providers/provider.go
+++ b/src/backend/providers/provider.go
@@ -149,6 +149,8 @@ func (p *Providers) GetProviderFromPath(host string, path string, body *[]byte, 
 		case ProviderTypeMistral:
 			provider = p.MistralProvider
 		}
+	case path == ProviderSubpathOpenAIResp:
+		provider = p.OpenAIProvider
 	case path == ProviderSubpathAnthropic:
 		provider = p.AnthropicProvider
 	case strings.HasPrefix(path, ProviderSubpathGemini):

--- a/src/backend/providers/providers_test.go
+++ b/src/backend/providers/providers_test.go
@@ -798,6 +798,38 @@ func TestMaybeConvertOpenAIRequest_ChatToResponses(t *testing.T) {
 			}
 		}
 	})
+
+	// A well-formed request carries either `messages` or `input`, not both. If a
+	// malformed request carries both, presence of `messages` wins and the
+	// converted messages overwrite any pre-existing `input`. This is by design:
+	// PII masking ran against `messages`, so the unmasked `input` must not
+	// survive into the upstream request.
+	t.Run("malformed request with both messages and input: input is overwritten", func(t *testing.T) {
+		body := []byte(`{
+			"model": "gpt-5",
+			"messages": [{"role":"user","content":"from messages"}],
+			"input": "from input (unmasked)"
+		}`)
+		out, path := MaybeConvertOpenAIRequest(body, ProviderSubpathOpenAI)
+		if path != ProviderSubpathOpenAIResp {
+			t.Fatalf("path = %q, want %q", path, ProviderSubpathOpenAIResp)
+		}
+		var data map[string]interface{}
+		if err := json.Unmarshal(out, &data); err != nil {
+			t.Fatalf("unmarshal: %v", err)
+		}
+		input, ok := data["input"].([]interface{})
+		if !ok {
+			t.Fatalf("input not an array, got %T (%v)", data["input"], data["input"])
+		}
+		if len(input) != 1 {
+			t.Fatalf("len(input) = %d, want 1", len(input))
+		}
+		item := input[0].(map[string]interface{})
+		if item["content"] != "from messages" {
+			t.Errorf("input[0].content = %q, want %q (pre-existing input must not survive)", item["content"], "from messages")
+		}
+	})
 }
 
 func TestMaybeConvertOpenAIRequest_ResponsesToChat(t *testing.T) {

--- a/src/backend/providers/providers_test.go
+++ b/src/backend/providers/providers_test.go
@@ -668,20 +668,32 @@ func TestIsReasoningModel(t *testing.T) {
 		model string
 		want  bool
 	}{
+		// gpt-5 family
 		{"gpt-5", true},
 		{"gpt-5-mini", true},
+		{"gpt-5-nano", true},
 		{"gpt-5-2025-08-07", true},
+		// o-series
 		{"o1", true},
 		{"o1-mini", true},
 		{"o1-preview", true},
+		{"o1-pro", true},
+		{"o1-2024-12-17", true},
 		{"o3", true},
 		{"o3-mini", true},
+		{"o3-pro", true},
 		{"o4-mini", true},
+		// non-reasoning chat models
 		{"gpt-4", false},
 		{"gpt-4o", false},
 		{"gpt-4-turbo", false},
 		{"gpt-3.5-turbo", false},
-		{"opus-4", false}, // starts with 'o' but not o[1-9]
+		// not in the allow-list (would have matched the old o[1-9] regex)
+		{"o2", false},
+		{"o5-mini", false},
+		// not OpenAI reasoning models at all
+		{"opus-4", false},
+		{"openai-something", false},
 		{"", false},
 	}
 	for _, tt := range tests {

--- a/src/backend/providers/providers_test.go
+++ b/src/backend/providers/providers_test.go
@@ -344,6 +344,527 @@ func TestOpenAIProvider_RestoreMaskedResponse(t *testing.T) {
 	})
 }
 
+// --- OpenAI Responses-API (reasoning-model endpoint) tests ---
+
+func TestOpenAIProvider_CreateMaskedRequest_ResponsesAPI(t *testing.T) {
+	p := NewOpenAIProvider("api.openai.com", "sk-test", nil)
+
+	t.Run("masks string input", func(t *testing.T) {
+		data := map[string]interface{}{
+			"model": "gpt-5",
+			"input": "Hello John Doe",
+		}
+
+		mapping, entities, err := p.CreateMaskedRequest(data, replaceMaskPII)
+		if err != nil {
+			t.Fatalf("CreateMaskedRequest() error = %v", err)
+		}
+		if len(mapping) == 0 {
+			t.Error("expected non-empty mapping")
+		}
+		if entities == nil || len(*entities) == 0 {
+			t.Error("expected non-empty entities")
+		}
+		if data["input"] != "Hello Jane Smith" {
+			t.Errorf("input = %q, want %q", data["input"], "Hello Jane Smith")
+		}
+	})
+
+	t.Run("masks string instructions", func(t *testing.T) {
+		data := map[string]interface{}{
+			"model":        "gpt-5",
+			"instructions": "Hello John Doe",
+			"input":        "noop",
+		}
+
+		_, _, err := p.CreateMaskedRequest(data, replaceMaskPII)
+		if err != nil {
+			t.Fatalf("CreateMaskedRequest() error = %v", err)
+		}
+		if data["instructions"] != "Hello Jane Smith" {
+			t.Errorf("instructions = %q, want %q", data["instructions"], "Hello Jane Smith")
+		}
+	})
+
+	t.Run("masks array input with string content", func(t *testing.T) {
+		data := map[string]interface{}{
+			"model": "gpt-5",
+			"input": []interface{}{
+				map[string]interface{}{"role": "user", "content": "Hello John Doe"},
+			},
+		}
+
+		_, _, err := p.CreateMaskedRequest(data, replaceMaskPII)
+		if err != nil {
+			t.Fatalf("CreateMaskedRequest() error = %v", err)
+		}
+		items := data["input"].([]interface{})
+		item := items[0].(map[string]interface{})
+		if item["content"] != "Hello Jane Smith" {
+			t.Errorf("content = %q, want %q", item["content"], "Hello Jane Smith")
+		}
+	})
+
+	t.Run("masks array input with content parts", func(t *testing.T) {
+		data := map[string]interface{}{
+			"model": "gpt-5",
+			"input": []interface{}{
+				map[string]interface{}{
+					"role": "user",
+					"content": []interface{}{
+						map[string]interface{}{"type": "input_text", "text": "Hello John Doe"},
+					},
+				},
+			},
+		}
+
+		_, _, err := p.CreateMaskedRequest(data, replaceMaskPII)
+		if err != nil {
+			t.Fatalf("CreateMaskedRequest() error = %v", err)
+		}
+		items := data["input"].([]interface{})
+		item := items[0].(map[string]interface{})
+		parts := item["content"].([]interface{})
+		part := parts[0].(map[string]interface{})
+		if part["text"] != "Hello Jane Smith" {
+			t.Errorf("text = %q, want %q", part["text"], "Hello Jane Smith")
+		}
+	})
+
+	t.Run("instructions-only request is valid", func(t *testing.T) {
+		data := map[string]interface{}{
+			"model":        "gpt-5",
+			"instructions": "Hello John Doe",
+		}
+		_, _, err := p.CreateMaskedRequest(data, replaceMaskPII)
+		if err != nil {
+			t.Fatalf("CreateMaskedRequest() error = %v", err)
+		}
+		if data["instructions"] != "Hello Jane Smith" {
+			t.Errorf("instructions = %q, want %q", data["instructions"], "Hello Jane Smith")
+		}
+	})
+}
+
+func TestOpenAIProvider_RestoreMaskedResponse_ResponsesAPI(t *testing.T) {
+	p := NewOpenAIProvider("api.openai.com", "sk-test", nil)
+
+	restoreJaneToJohn := func(text string, m map[string]string) string {
+		if text == "Hello Jane Smith" {
+			return "Hello John Doe"
+		}
+		return text
+	}
+
+	t.Run("restores PII in output content and output_text", func(t *testing.T) {
+		data := map[string]interface{}{
+			"output": []interface{}{
+				map[string]interface{}{
+					"type": "message",
+					"role": "assistant",
+					"content": []interface{}{
+						map[string]interface{}{"type": "output_text", "text": "Hello Jane Smith"},
+					},
+				},
+			},
+			"output_text": "Hello Jane Smith",
+		}
+
+		err := p.RestoreMaskedResponse(data, map[string]string{"Jane Smith": "John Doe"}, "", restoreJaneToJohn, falseFunc, falseFunc, falseFunc)
+		if err != nil {
+			t.Fatalf("RestoreMaskedResponse() error = %v", err)
+		}
+
+		output := data["output"].([]interface{})
+		item := output[0].(map[string]interface{})
+		contents := item["content"].([]interface{})
+		part := contents[0].(map[string]interface{})
+		if part["text"] != "Hello John Doe" {
+			t.Errorf("output text = %q, want %q", part["text"], "Hello John Doe")
+		}
+		if data["output_text"] != "Hello John Doe" {
+			t.Errorf("output_text = %q, want %q", data["output_text"], "Hello John Doe")
+		}
+	})
+
+	t.Run("ignores non-message output items (e.g. reasoning)", func(t *testing.T) {
+		data := map[string]interface{}{
+			"output": []interface{}{
+				map[string]interface{}{
+					"type":    "reasoning",
+					"summary": []interface{}{},
+				},
+				map[string]interface{}{
+					"type": "message",
+					"content": []interface{}{
+						map[string]interface{}{"type": "output_text", "text": "Hello Jane Smith"},
+					},
+				},
+			},
+		}
+
+		err := p.RestoreMaskedResponse(data, map[string]string{"Jane Smith": "John Doe"}, "", restoreJaneToJohn, falseFunc, falseFunc, falseFunc)
+		if err != nil {
+			t.Fatalf("RestoreMaskedResponse() error = %v", err)
+		}
+
+		output := data["output"].([]interface{})
+		msg := output[1].(map[string]interface{})
+		contents := msg["content"].([]interface{})
+		part := contents[0].(map[string]interface{})
+		if part["text"] != "Hello John Doe" {
+			t.Errorf("text = %q, want %q", part["text"], "Hello John Doe")
+		}
+	})
+
+	t.Run("adds proxy notice on message items and output_text", func(t *testing.T) {
+		data := map[string]interface{}{
+			"output": []interface{}{
+				map[string]interface{}{
+					"type": "message",
+					"content": []interface{}{
+						map[string]interface{}{"type": "output_text", "text": "Hello"},
+					},
+				},
+			},
+			"output_text": "Hello",
+		}
+		notice := "\n[proxy notice]"
+
+		err := p.RestoreMaskedResponse(data, map[string]string{}, notice, noopRestorePII, falseFunc, falseFunc, trueFunc)
+		if err != nil {
+			t.Fatalf("RestoreMaskedResponse() error = %v", err)
+		}
+
+		output := data["output"].([]interface{})
+		item := output[0].(map[string]interface{})
+		contents := item["content"].([]interface{})
+		part := contents[0].(map[string]interface{})
+		expected := "Hello" + notice
+		if part["text"] != expected {
+			t.Errorf("output text = %q, want %q", part["text"], expected)
+		}
+		if data["output_text"] != expected {
+			t.Errorf("output_text = %q, want %q", data["output_text"], expected)
+		}
+	})
+
+	t.Run("output_text only (no output array)", func(t *testing.T) {
+		data := map[string]interface{}{
+			"output_text": "Hello Jane Smith",
+		}
+
+		err := p.RestoreMaskedResponse(data, map[string]string{"Jane Smith": "John Doe"}, "", restoreJaneToJohn, falseFunc, falseFunc, falseFunc)
+		if err != nil {
+			t.Fatalf("RestoreMaskedResponse() error = %v", err)
+		}
+		if data["output_text"] != "Hello John Doe" {
+			t.Errorf("output_text = %q, want %q", data["output_text"], "Hello John Doe")
+		}
+	})
+}
+
+func TestOpenAIProvider_ExtractRequestText_ResponsesAPI(t *testing.T) {
+	p := NewOpenAIProvider("api.openai.com", "sk-test", nil)
+
+	t.Run("string input", func(t *testing.T) {
+		data := map[string]interface{}{
+			"model": "gpt-5",
+			"input": "Hello world",
+		}
+		got, err := p.ExtractRequestText(data)
+		if err != nil {
+			t.Fatalf("ExtractRequestText() error = %v", err)
+		}
+		if got != "Hello world\n" {
+			t.Errorf("ExtractRequestText() = %q, want %q", got, "Hello world\n")
+		}
+	})
+
+	t.Run("instructions + array input with text parts", func(t *testing.T) {
+		data := map[string]interface{}{
+			"model":        "gpt-5",
+			"instructions": "Be brief",
+			"input": []interface{}{
+				map[string]interface{}{
+					"role": "user",
+					"content": []interface{}{
+						map[string]interface{}{"type": "input_text", "text": "Hello"},
+					},
+				},
+			},
+		}
+		got, err := p.ExtractRequestText(data)
+		if err != nil {
+			t.Fatalf("ExtractRequestText() error = %v", err)
+		}
+		if got != "Be brief\nHello\n" {
+			t.Errorf("ExtractRequestText() = %q, want %q", got, "Be brief\nHello\n")
+		}
+	})
+}
+
+func TestOpenAIProvider_ExtractResponseText_ResponsesAPI(t *testing.T) {
+	p := NewOpenAIProvider("api.openai.com", "sk-test", nil)
+
+	t.Run("output array with text", func(t *testing.T) {
+		data := map[string]interface{}{
+			"output": []interface{}{
+				map[string]interface{}{
+					"type": "message",
+					"content": []interface{}{
+						map[string]interface{}{"type": "output_text", "text": "Hi there"},
+					},
+				},
+			},
+		}
+		got, err := p.ExtractResponseText(data)
+		if err != nil {
+			t.Fatalf("ExtractResponseText() error = %v", err)
+		}
+		if got != "Hi there\n" {
+			t.Errorf("ExtractResponseText() = %q, want %q", got, "Hi there\n")
+		}
+	})
+
+	t.Run("output_text only", func(t *testing.T) {
+		data := map[string]interface{}{
+			"output_text": "Hi there",
+		}
+		got, err := p.ExtractResponseText(data)
+		if err != nil {
+			t.Fatalf("ExtractResponseText() error = %v", err)
+		}
+		if got != "Hi there\n" {
+			t.Errorf("ExtractResponseText() = %q, want %q", got, "Hi there\n")
+		}
+	})
+}
+
+func TestOpenAIProvider_ShapeDetection(t *testing.T) {
+	tests := []struct {
+		name     string
+		data     map[string]interface{}
+		isResp   bool
+	}{
+		{"chat completions with messages", map[string]interface{}{"messages": []interface{}{}}, false},
+		{"responses with input string", map[string]interface{}{"input": "hi"}, true},
+		{"responses with input array", map[string]interface{}{"input": []interface{}{}}, true},
+		{"responses with instructions only", map[string]interface{}{"instructions": "be brief"}, true},
+		{"neither (no schema fields)", map[string]interface{}{"model": "gpt-4"}, false},
+		{"both messages and input prefers chat", map[string]interface{}{"messages": []interface{}{}, "input": "hi"}, false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := isResponsesAPIRequest(tt.data); got != tt.isResp {
+				t.Errorf("isResponsesAPIRequest() = %v, want %v", got, tt.isResp)
+			}
+		})
+	}
+}
+
+func TestIsReasoningModel(t *testing.T) {
+	tests := []struct {
+		model string
+		want  bool
+	}{
+		{"gpt-5", true},
+		{"gpt-5-mini", true},
+		{"gpt-5-2025-08-07", true},
+		{"o1", true},
+		{"o1-mini", true},
+		{"o1-preview", true},
+		{"o3", true},
+		{"o3-mini", true},
+		{"o4-mini", true},
+		{"gpt-4", false},
+		{"gpt-4o", false},
+		{"gpt-4-turbo", false},
+		{"gpt-3.5-turbo", false},
+		{"opus-4", false}, // starts with 'o' but not o[1-9]
+		{"", false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.model, func(t *testing.T) {
+			if got := isReasoningModel(tt.model); got != tt.want {
+				t.Errorf("isReasoningModel(%q) = %v, want %v", tt.model, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestMaybeConvertOpenAIRequest_ChatToResponses(t *testing.T) {
+	t.Run("reasoning model on chat path is converted", func(t *testing.T) {
+		body := []byte(`{
+			"model": "gpt-5-2025-08-07",
+			"max_tokens": 1000,
+			"messages": [
+				{"role": "system", "content": "Be concise"},
+				{"role": "user", "content": "Hi"}
+			]
+		}`)
+
+		out, path := MaybeConvertOpenAIRequest(body, ProviderSubpathOpenAI)
+		if path != ProviderSubpathOpenAIResp {
+			t.Fatalf("path = %q, want %q", path, ProviderSubpathOpenAIResp)
+		}
+
+		var data map[string]interface{}
+		if err := json.Unmarshal(out, &data); err != nil {
+			t.Fatalf("unmarshal: %v", err)
+		}
+
+		if _, ok := data["messages"]; ok {
+			t.Error("messages field should be removed")
+		}
+		if _, ok := data["max_tokens"]; ok {
+			t.Error("max_tokens should be renamed")
+		}
+		if mt, ok := data["max_output_tokens"].(float64); !ok || mt != 1000 {
+			t.Errorf("max_output_tokens = %v, want 1000", data["max_output_tokens"])
+		}
+		if data["instructions"] != "Be concise" {
+			t.Errorf("instructions = %q, want %q", data["instructions"], "Be concise")
+		}
+		input, ok := data["input"].([]interface{})
+		if !ok {
+			t.Fatalf("input not an array, got %T", data["input"])
+		}
+		if len(input) != 1 {
+			t.Fatalf("len(input) = %d, want 1 (system message moved to instructions)", len(input))
+		}
+		item := input[0].(map[string]interface{})
+		if item["role"] != "user" || item["content"] != "Hi" {
+			t.Errorf("input[0] = %v, want {role:user, content:Hi}", item)
+		}
+	})
+
+	t.Run("non-reasoning model on chat path is not converted", func(t *testing.T) {
+		body := []byte(`{"model":"gpt-4","messages":[{"role":"user","content":"Hi"}]}`)
+		out, path := MaybeConvertOpenAIRequest(body, ProviderSubpathOpenAI)
+		if path != ProviderSubpathOpenAI {
+			t.Errorf("path = %q, want unchanged %q", path, ProviderSubpathOpenAI)
+		}
+		if string(out) != string(body) {
+			t.Errorf("body should be unchanged")
+		}
+	})
+
+	t.Run("multiple system messages are joined into instructions", func(t *testing.T) {
+		body := []byte(`{
+			"model": "gpt-5",
+			"messages": [
+				{"role": "system", "content": "Be polite"},
+				{"role": "developer", "content": "Use markdown"},
+				{"role": "user", "content": "Hello"}
+			]
+		}`)
+		out, _ := MaybeConvertOpenAIRequest(body, ProviderSubpathOpenAI)
+		var data map[string]interface{}
+		_ = json.Unmarshal(out, &data)
+		want := "Be polite\n\nUse markdown"
+		if data["instructions"] != want {
+			t.Errorf("instructions = %q, want %q", data["instructions"], want)
+		}
+	})
+
+	t.Run("strips chat-completions-only fields", func(t *testing.T) {
+		body := []byte(`{
+			"model": "gpt-5",
+			"messages": [{"role":"user","content":"hi"}],
+			"frequency_penalty": 0.5,
+			"presence_penalty": 0.3,
+			"n": 2,
+			"logprobs": true
+		}`)
+		out, _ := MaybeConvertOpenAIRequest(body, ProviderSubpathOpenAI)
+		var data map[string]interface{}
+		_ = json.Unmarshal(out, &data)
+		for _, k := range []string{"frequency_penalty", "presence_penalty", "n", "logprobs"} {
+			if _, ok := data[k]; ok {
+				t.Errorf("field %q should be stripped", k)
+			}
+		}
+	})
+}
+
+func TestMaybeConvertOpenAIRequest_ResponsesToChat(t *testing.T) {
+	t.Run("non-reasoning model on responses path is converted", func(t *testing.T) {
+		body := []byte(`{
+			"model": "gpt-4",
+			"max_output_tokens": 500,
+			"instructions": "Be brief",
+			"input": "Tell me a joke"
+		}`)
+
+		out, path := MaybeConvertOpenAIRequest(body, ProviderSubpathOpenAIResp)
+		if path != ProviderSubpathOpenAI {
+			t.Fatalf("path = %q, want %q", path, ProviderSubpathOpenAI)
+		}
+
+		var data map[string]interface{}
+		_ = json.Unmarshal(out, &data)
+		if _, ok := data["input"]; ok {
+			t.Error("input should be removed")
+		}
+		if _, ok := data["instructions"]; ok {
+			t.Error("instructions should be folded into messages")
+		}
+		if mt, ok := data["max_tokens"].(float64); !ok || mt != 500 {
+			t.Errorf("max_tokens = %v, want 500", data["max_tokens"])
+		}
+		messages, ok := data["messages"].([]interface{})
+		if !ok || len(messages) != 2 {
+			t.Fatalf("messages = %v, want 2 messages", data["messages"])
+		}
+		sys := messages[0].(map[string]interface{})
+		if sys["role"] != "system" || sys["content"] != "Be brief" {
+			t.Errorf("system message = %v", sys)
+		}
+		user := messages[1].(map[string]interface{})
+		if user["role"] != "user" || user["content"] != "Tell me a joke" {
+			t.Errorf("user message = %v", user)
+		}
+	})
+
+	t.Run("reasoning model on responses path is not converted", func(t *testing.T) {
+		body := []byte(`{"model":"gpt-5","input":"hi"}`)
+		out, path := MaybeConvertOpenAIRequest(body, ProviderSubpathOpenAIResp)
+		if path != ProviderSubpathOpenAIResp {
+			t.Errorf("path should be unchanged: got %q", path)
+		}
+		if string(out) != string(body) {
+			t.Errorf("body should be unchanged")
+		}
+	})
+}
+
+func TestMaybeConvertOpenAIRequest_NoOps(t *testing.T) {
+	t.Run("invalid JSON passes through", func(t *testing.T) {
+		body := []byte(`not json`)
+		out, path := MaybeConvertOpenAIRequest(body, ProviderSubpathOpenAI)
+		if path != ProviderSubpathOpenAI || string(out) != string(body) {
+			t.Error("invalid JSON should pass through unchanged")
+		}
+	})
+
+	t.Run("missing model passes through", func(t *testing.T) {
+		body := []byte(`{"messages":[]}`)
+		out, path := MaybeConvertOpenAIRequest(body, ProviderSubpathOpenAI)
+		if path != ProviderSubpathOpenAI || string(out) != string(body) {
+			t.Error("missing model should pass through unchanged")
+		}
+	})
+
+	t.Run("unrelated path passes through", func(t *testing.T) {
+		body := []byte(`{"model":"gpt-5","messages":[]}`)
+		out, path := MaybeConvertOpenAIRequest(body, "/v1/embeddings")
+		if path != "/v1/embeddings" || string(out) != string(body) {
+			t.Error("unrelated path should pass through unchanged")
+		}
+	})
+}
+
 func TestOpenAIProvider_SetAuthHeaders(t *testing.T) {
 	t.Run("sets Authorization header", func(t *testing.T) {
 		p := NewOpenAIProvider("api.openai.com", "sk-test-key", nil)

--- a/src/backend/proxy/handler.go
+++ b/src/backend/proxy/handler.go
@@ -435,7 +435,21 @@ func (h *Handler) checkRequestPII(body string, provider *providers.Provider) (st
 
 // createAndSendProxyRequest creates and sends the proxy request to provider
 func (h *Handler) createAndSendProxyRequest(r *http.Request, body []byte, provider *providers.Provider) (*http.Response, error) {
-	targetURL, err := h.buildTargetURL(r, provider)
+	requestPath := r.URL.Path
+
+	// OpenAI reasoning models (gpt-5*, o-series) must use /v1/responses;
+	// non-reasoning models on /v1/responses must be rewritten to chat
+	// completions. Apply after PII masking so masked content carries over.
+	if _, ok := (*provider).(*providers.OpenAIProvider); ok {
+		convertedBody, convertedPath := providers.MaybeConvertOpenAIRequest(body, requestPath)
+		if convertedPath != requestPath {
+			log.Printf("[Proxy] OpenAI schema converted: %s -> %s", requestPath, convertedPath)
+		}
+		body = convertedBody
+		requestPath = convertedPath
+	}
+
+	targetURL, err := h.buildTargetURL(r, provider, requestPath)
 	if err != nil {
 		return nil, fmt.Errorf("failed to build target URL: %w", err)
 	}
@@ -464,8 +478,10 @@ func (h *Handler) createAndSendProxyRequest(r *http.Request, body []byte, provid
 	return resp, nil
 }
 
-// buildTargetURL builds the target URL for the proxy request
-func (h *Handler) buildTargetURL(r *http.Request, provider *providers.Provider) (string, error) {
+// buildTargetURL builds the target URL for the proxy request. requestPath may
+// differ from r.URL.Path when a provider has rewritten it (e.g. OpenAI
+// reasoning-model routing from /v1/chat/completions to /v1/responses).
+func (h *Handler) buildTargetURL(r *http.Request, provider *providers.Provider, requestPath string) (string, error) {
 	useHttps := true
 	baseURL := strings.TrimSuffix((*provider).GetBaseURL(useHttps), "/")
 
@@ -477,7 +493,6 @@ func (h *Handler) buildTargetURL(r *http.Request, provider *providers.Provider) 
 
 	// If the base URL has a path prefix and the request path starts with it,
 	// strip the prefix to avoid duplication (e.g. /v1 + /v1/chat/completions → /v1/chat/completions)
-	requestPath := r.URL.Path
 	basePath := strings.TrimSuffix(parsed.Path, "/")
 	if basePath != "" && strings.HasPrefix(requestPath, basePath) {
 		requestPath = requestPath[len(basePath):]

--- a/src/backend/proxy/handler_test.go
+++ b/src/backend/proxy/handler_test.go
@@ -395,7 +395,7 @@ func TestHandler_BuildTargetURL(t *testing.T) {
 			if tt.query != "" {
 				req.URL.RawQuery = tt.query
 			}
-			got, err := h.buildTargetURL(req, &tt.provider)
+			got, err := h.buildTargetURL(req, &tt.provider, req.URL.Path)
 			if err != nil {
 				t.Fatalf("buildTargetURL() error = %v", err)
 			}
@@ -409,7 +409,7 @@ func TestHandler_BuildTargetURL(t *testing.T) {
 		p := providers.NewOpenAIProvider("https://api.openai.com/v1", "sk-test", nil)
 		var prov providers.Provider = p
 		req := httptest.NewRequest("POST", "/v1/chat/completions", nil)
-		got, err := h.buildTargetURL(req, &prov)
+		got, err := h.buildTargetURL(req, &prov, req.URL.Path)
 		if err != nil {
 			t.Fatalf("buildTargetURL() error = %v", err)
 		}


### PR DESCRIPTION
Closes #461

## Summary
- Reasoning OpenAI models (`gpt-5*`, `o1*`, `o3*`, `o4*`) sent to
  `/v1/chat/completions` were returning 400 from upstream — those models
  require the Responses API. The proxy now converts the request schema and
  rewrites the path after PII masking, so masked content carries over.
- Response-side restoration now walks the Responses-API shape
  (`output[].content[].text` + top-level `output_text`) in addition to
  Chat-Completions `choices[]`, so masked placeholders no longer leak back
  to the client when a `gpt-5` request flows through `/v1/responses`.
- Native `/v1/responses` traffic (any model) is now masked on the way out:
  `CreateMaskedRequest` walks `input` (string or array, including content
  parts) and `instructions` when `messages` is absent.

The split is based on **reasoning vs non-reasoning model family**, not
GPT-4 vs GPT-5. Schema detection happens by inspecting payload fields
(`messages` vs `input`/`instructions`, `choices` vs `output`/`output_text`)
so the proxy doesn't bake in a version allow-list.

## What changed
- `src/backend/providers/openai.go`
  - `MaybeConvertOpenAIRequest`: chat→responses for reasoning models,
    responses→chat for non-reasoning models. Folds `system`/`developer`
    messages into `instructions`, renames `max_tokens` →
    `max_output_tokens`, strips Chat-Completions-only fields
    (`frequency_penalty`, `presence_penalty`, `logit_bias`, `logprobs`,
    `top_logprobs`, `n`, `stop`).
  - `isReasoningModel`: matches `gpt-5*` and the o-series `o[1-9]…`.
  - `CreateMaskedRequest` / `RestoreMaskedResponse` /
    `ExtractRequestText` / `ExtractResponseText`: dispatch on payload
    shape; new walkers for the Responses-API request and response
    shapes. Proxy notice is appended only to `message`-type output
    items so it doesn't get pinned to `reasoning` items.
- `src/backend/providers/provider.go`
  - Registers `/v1/responses` as an OpenAI subpath in
    `GetProviderFromPath`.
- `src/backend/proxy/handler.go`
  - `createAndSendProxyRequest` calls `MaybeConvertOpenAIRequest` after
    PII masking and threads the rewritten path through
    `buildTargetURL`. `buildTargetURL` takes the path as a parameter
    so callers can pass a rewritten value.

## Out of scope
- Streaming (`text/event-stream`) — tracked separately.
- Tool-call and structured-output field differences beyond the top-level
  schema mapping.
- Converting the Responses-API response shape back to Chat-Completions
  for clients that called `/v1/chat/completions`. Clients see the
  Responses shape on the wire.

## Test plan
- [x] `go test ./src/backend/...` passes
- [x] New unit tests:
  - `TestIsReasoningModel` (table covering gpt-5/o-series/gpt-4/etc.)
  - `TestMaybeConvertOpenAIRequest_ChatToResponses` (system→instructions,
    `max_tokens` rename, stripped fields, multi-system join)
  - `TestMaybeConvertOpenAIRequest_ResponsesToChat`
  - `TestMaybeConvertOpenAIRequest_NoOps` (invalid JSON, missing model,
    unrelated path)
  - `TestOpenAIProvider_CreateMaskedRequest_ResponsesAPI` (string
    `input`, `instructions`, array with string content, array with
    content parts, instructions-only)
  - `TestOpenAIProvider_RestoreMaskedResponse_ResponsesAPI` (output +
    output_text, ignoring `reasoning` items, proxy notice placement,
    output_text-only)
  - `TestOpenAIProvider_ShapeDetection`
- [x] Manual: send the failing request from #461 (gpt-5 with `max_tokens`
  on `/v1/chat/completions`) and confirm 200 + correctly restored PII.
