### PR TITLE
feat: add link to Kiji Chrome Extension

### DIFF
--- a/src/frontend/src/components/modals/AboutModal.tsx
+++ b/src/frontend/src/components/modals/AboutModal.tsx
@@ -108,6 +108,14 @@ export default function AboutModal({ isOpen, onClose }: AboutModalProps) {
               Documentation →
             </a>
             <a
+              href="https://chromewebstore.google.com/detail/kiji-privacy-proxy-extens/knnjemahdeioghdgcpeikepmlajfihin"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="block text-sm text-blue-600 hover:text-blue-700 hover:underline"
+            >
+              Kiji Chrome Extension →
+            </a>
+            <a
               href="https://github.com/dataiku/kiji-proxy/issues/new?template=10_bug_report.yml"
               target="_blank"
               rel="noopener noreferrer"

--- a/src/frontend/src/electron/electron-main.js
+++ b/src/frontend/src/electron/electron-main.js
@@ -678,6 +678,10 @@ function updateTrayMenu() {
         }, 100);
       },
     },
+
+    // TODO: Add link to https://chromewebstore.google.com/detail/kiji-privacy-proxy-extens/knnjemahdeioghdgcpeikepmlajfihin?hl=en-US&utm_source=ext_sidebar&pli=1
+    //
+
     { type: "separator" },
     {
       label: "Terms && Conditions",
@@ -695,6 +699,13 @@ function updateTrayMenu() {
       click: () =>
         shell.openExternal(
           "https://github.com/dataiku/kiji-proxy/blob/main/docs/README.md"
+        ),
+    },
+    {
+      label: "Kiji Chrome Extension",
+      click: () =>
+        shell.openExternal(
+          "https://chromewebstore.google.com/detail/kiji-privacy-proxy-extens/knnjemahdeioghdgcpeikepmlajfihin"
         ),
     },
     {


### PR DESCRIPTION
## Summary
- Add a link to the Kiji Privacy Proxy Chrome Extension in the About modal's Links section
- Add a matching entry in the Electron tray menu

## Test plan
- [x] Open the About modal and click the "Kiji Chrome Extension" link — confirm it opens the Chrome Web Store listing
- [x] Open the Electron tray menu and click "Kiji Chrome Extension" — confirm it opens the same URL in the default browser