### PR TITLE
feat: log Chrome extension PII checks to /logs

### DIFF
--- a/chrome-extension/background.js
+++ b/chrome-extension/background.js
@@ -170,7 +170,7 @@ chrome.runtime.onStartup.addListener(() => {
 
 // --- Message handling ---
 
-async function handlePIICheck(text) {
+async function handlePIICheck(text, site) {
   // Pull the latest backendUrl every time — the service worker may have been
   // torn down since startup, which resets in-memory `backendUrl` to the
   // default even if the user configured a different one in options.
@@ -186,7 +186,7 @@ async function handlePIICheck(text) {
     response = await fetch(url, {
       method: "POST",
       headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ message: text }),
+      body: JSON.stringify({ message: text, site: site || "" }),
       signal: AbortSignal.timeout(10000),
     });
   } catch (e) {
@@ -227,7 +227,7 @@ async function handlePIICheck(text) {
 
 chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
   if (message.type === "check-pii-text") {
-    handlePIICheck(message.text).then(sendResponse);
+    handlePIICheck(message.text, message.site).then(sendResponse);
     return true; // keep channel open for async sendResponse
   }
 

--- a/chrome-extension/content.js
+++ b/chrome-extension/content.js
@@ -2,7 +2,7 @@
 (function () {
   "use strict";
 
-  const DEFAULT_API_BASE = "http://localhost:8081";
+  const DEFAULT_API_BASE = "http://localhost:8080";
   let apiBase = DEFAULT_API_BASE;
   let isChecking = false;
   let maskedTextPending = null;

--- a/chrome-extension/content.js
+++ b/chrome-extension/content.js
@@ -331,6 +331,7 @@
       const response = await chrome.runtime.sendMessage({
         type: "check-pii-text",
         text: text,
+        site: window.location.hostname,
       });
 
       if (!response) {

--- a/src/backend/proxy/handler.go
+++ b/src/backend/proxy/handler.go
@@ -306,6 +306,53 @@ func (h *Handler) MaskPIIInText(text string) (string, map[string]string, []pii.E
 	return h.maskPIIInText(text, "[PIICheck]")
 }
 
+// MaskPIIInTextWithLogging masks PII in a plain text input and records
+// request_original + request_masked entries to the logging DB so the call
+// surfaces in the /logs UI. The two entries share a transaction ID embedded as
+// _transaction_id in a JSON envelope around the text — the same convention the
+// proxy flow uses, which lets the frontend pair them.
+func (h *Handler) MaskPIIInTextWithLogging(ctx context.Context, text string) (string, map[string]string, []pii.Entity) {
+	maskedText, maskedToOriginal, entities := h.maskPIIInText(text, "[PIICheck]")
+
+	if h.loggingDB == nil {
+		return maskedText, maskedToOriginal, entities
+	}
+
+	transactionID := uuid.New().String()
+	logCtx, cancel := context.WithTimeout(ctx, 5*time.Second)
+	defer cancel()
+
+	original := wrapPIICheckMessage(text, transactionID)
+	if err := h.loggingDB.InsertLog(logCtx, original, "request_original", entities, false); err != nil {
+		log.Printf("[PIICheck] ⚠️  Failed to log original request: %v", err)
+	}
+
+	masked := wrapPIICheckMessage(maskedText, transactionID)
+	if err := h.loggingDB.InsertLog(logCtx, masked, "request_masked", entities, false); err != nil {
+		log.Printf("[PIICheck] ⚠️  Failed to log masked request: %v", err)
+	}
+
+	return maskedText, maskedToOriginal, entities
+}
+
+// wrapPIICheckMessage wraps a plain-text PII check input in an OpenAI-style
+// messages envelope so parseMessagesFromLogMessage populates the `messages` /
+// `formatted_messages` columns and the entry renders in the /logs UI the same
+// way as proxied requests. _transaction_id pairs the original/masked rows.
+func wrapPIICheckMessage(text, transactionID string) string {
+	envelope := map[string]any{
+		"messages": []map[string]string{
+			{"role": "user", "content": text},
+		},
+		"_transaction_id": transactionID,
+	}
+	data, err := json.Marshal(envelope)
+	if err != nil {
+		return text
+	}
+	return string(data)
+}
+
 // ProcessedRequest contains the result of processing a request through the PII pipeline
 type ProcessedRequest struct {
 	RedactedBody     []byte

--- a/src/backend/proxy/handler.go
+++ b/src/backend/proxy/handler.go
@@ -310,8 +310,10 @@ func (h *Handler) MaskPIIInText(text string) (string, map[string]string, []pii.E
 // request_original + request_masked entries to the logging DB so the call
 // surfaces in the /logs UI. The two entries share a transaction ID embedded as
 // _transaction_id in a JSON envelope around the text — the same convention the
-// proxy flow uses, which lets the frontend pair them.
-func (h *Handler) MaskPIIInTextWithLogging(ctx context.Context, text string) (string, map[string]string, []pii.Entity) {
+// proxy flow uses, which lets the frontend pair them. site (hostname of the
+// page that triggered the check) is recorded as the "model" column so calls
+// from different AI providers are distinguishable in the UI.
+func (h *Handler) MaskPIIInTextWithLogging(ctx context.Context, text, site string) (string, map[string]string, []pii.Entity) {
 	maskedText, maskedToOriginal, entities := h.maskPIIInText(text, "[PIICheck]")
 
 	if h.loggingDB == nil {
@@ -322,12 +324,12 @@ func (h *Handler) MaskPIIInTextWithLogging(ctx context.Context, text string) (st
 	logCtx, cancel := context.WithTimeout(ctx, 5*time.Second)
 	defer cancel()
 
-	original := wrapPIICheckMessage(text, transactionID)
+	original := wrapPIICheckMessage(text, site, transactionID)
 	if err := h.loggingDB.InsertLog(logCtx, original, "request_original", entities, false); err != nil {
 		log.Printf("[PIICheck] ⚠️  Failed to log original request: %v", err)
 	}
 
-	masked := wrapPIICheckMessage(maskedText, transactionID)
+	masked := wrapPIICheckMessage(maskedText, site, transactionID)
 	if err := h.loggingDB.InsertLog(logCtx, masked, "request_masked", entities, false); err != nil {
 		log.Printf("[PIICheck] ⚠️  Failed to log masked request: %v", err)
 	}
@@ -338,13 +340,17 @@ func (h *Handler) MaskPIIInTextWithLogging(ctx context.Context, text string) (st
 // wrapPIICheckMessage wraps a plain-text PII check input in an OpenAI-style
 // messages envelope so parseMessagesFromLogMessage populates the `messages` /
 // `formatted_messages` columns and the entry renders in the /logs UI the same
-// way as proxied requests. _transaction_id pairs the original/masked rows.
-func wrapPIICheckMessage(text, transactionID string) string {
+// way as proxied requests. _transaction_id pairs the original/masked rows;
+// site (when provided) is surfaced as the "model" column.
+func wrapPIICheckMessage(text, site, transactionID string) string {
 	envelope := map[string]any{
 		"messages": []map[string]string{
 			{"role": "user", "content": text},
 		},
 		"_transaction_id": transactionID,
+	}
+	if site != "" {
+		envelope["model"] = site
 	}
 	data, err := json.Marshal(envelope)
 	if err != nil {

--- a/src/backend/server/server.go
+++ b/src/backend/server/server.go
@@ -615,8 +615,8 @@ func (s *Server) handlePIICheck(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Use the handler's masking service to check for PII
-	maskedText, maskedToOriginal, entities := s.handler.MaskPIIInText(req.Message)
+	// Mask + persist request_original / request_masked so the call appears in /logs.
+	maskedText, maskedToOriginal, entities := s.handler.MaskPIIInTextWithLogging(r.Context(), req.Message)
 
 	// masked -> original map (consumed by UI)
 	entityDetails := make(map[string]string)

--- a/src/backend/server/server.go
+++ b/src/backend/server/server.go
@@ -556,6 +556,10 @@ func (s *Server) handleModelSecurity(w http.ResponseWriter, r *http.Request) {
 // PIICheckRequest represents the request body for PII checking
 type PIICheckRequest struct {
 	Message string `json:"message"`
+	// Site is the hostname of the page that triggered the check (e.g.
+	// "chatgpt.com"). Recorded as the "model" column in /logs so calls from
+	// different AI providers are distinguishable in the UI.
+	Site string `json:"site,omitempty"`
 }
 
 // DetectedEntity represents a single detected PII entity with its label and
@@ -616,7 +620,7 @@ func (s *Server) handlePIICheck(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Mask + persist request_original / request_masked so the call appears in /logs.
-	maskedText, maskedToOriginal, entities := s.handler.MaskPIIInTextWithLogging(r.Context(), req.Message)
+	maskedText, maskedToOriginal, entities := s.handler.MaskPIIInTextWithLogging(r.Context(), req.Message, req.Site)
 
 	// masked -> original map (consumed by UI)
 	entityDetails := make(map[string]string)


### PR DESCRIPTION
The `/api/pii/check` handler used by the Chrome extension called
`MaskPIIInText`, which only masks — it never wrote to the logging DB.
As a result, extension traffic was invisible in the `/logs` UI while
proxied LLM requests showed up normally.

Adds `MaskPIIInTextWithLogging` on `proxy.Handler` that masks and
inserts `request_original` + `request_masked` rows linked by a shared
`_transaction_id`, mirroring the proxy flow. Wraps the input in an
OpenAI-style `messages` envelope so the entries render with
`formatted_messages` like proxied requests. `handlePIICheck` is wired
to the new method.

Also fixes a stale `http://localhost:8081` default in
`chrome-extension/content.js` so it matches `CONFIG.DEFAULT_API_BASE`
(`http://localhost:8080`).

**Request**
<img width="516" height="445" alt="Screenshot 2026-05-28 at 2 57 57 PM" src="https://github.com/user-attachments/assets/22f3ddc0-280d-4e94-82a4-72623d969ac7" />

**This is how it shows up in the logs**
<img width="785" height="203" alt="Screenshot 2026-05-28 at 2 58 04 PM" src="https://github.com/user-attachments/assets/e8c30c7c-2d50-42d6-91ea-63c4c6199176" />


