### PR TITLE
fix: publish Homebrew cask on first release

### DIFF
--- a/.changeset/upset-clubs-yawn.md
+++ b/.changeset/upset-clubs-yawn.md
@@ -1,0 +1,5 @@
+---
+"kiji-privacy-proxy": patch
+---
+
+Fixed homebrew release

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -127,7 +127,12 @@ jobs:
 
           ### macOS Installation
 
-          **Quick Start:**
+          **Homebrew (recommended):**
+          ```bash
+          brew install --cask dataiku/tap/kiji-privacy-proxy
+          ```
+
+          **Or download manually:**
           1. Download `Kiji-Privacy-Proxy-${{ steps.version.outputs.version }}.dmg`
           2. Open the DMG and drag to Applications
           3. Launch "Kiji Privacy Proxy"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -396,11 +396,16 @@ jobs:
           git config user.name  "${APP_SLUG}[bot]"
           git config user.email "${APP_SLUG}[bot]@users.noreply.github.com"
 
-          if git diff --quiet -- Casks/kiji-privacy-proxy.rb; then
+          # Stage first, then compare the index against HEAD. `git diff --quiet
+          # -- <path>` ignores untracked files, so on the first publish (when
+          # the cask does not yet exist in the tap) it would wrongly report
+          # "nothing to commit" and never push. `git diff --cached --quiet`
+          # detects both brand-new and modified files.
+          git add Casks/kiji-privacy-proxy.rb
+          if git diff --cached --quiet; then
             echo "::notice::Cask already at ${VERSION}, nothing to commit."
             exit 0
           fi
 
-          git add Casks/kiji-privacy-proxy.rb
           git commit -m "kiji-privacy-proxy ${VERSION}"
           git push origin HEAD:main

--- a/README.md
+++ b/README.md
@@ -65,11 +65,16 @@ When using AI services like OpenAI or Anthropic, sensitive data in your prompts 
 ### For Users
 
 **macOS (Desktop App):**
-```bash
-# Download from releases
-# https://github.com/dataiku/kiji-proxy/releases
 
-# Install
+Homebrew (recommended):
+```bash
+brew install --cask dataiku/tap/kiji-privacy-proxy
+```
+
+Or download manually:
+```bash
+# Download the latest DMG from
+# https://github.com/dataiku/kiji-proxy/releases
 open Kiji-Privacy-Proxy-*.dmg
 # Drag to Applications folder
 ```

--- a/docs/01-getting-started.md
+++ b/docs/01-getting-started.md
@@ -55,6 +55,16 @@ The backend supports two proxy modes that can run simultaneously:
 
 ### macOS (Desktop App)
 
+**Homebrew (recommended):**
+
+```bash
+brew install --cask dataiku/tap/kiji-privacy-proxy
+```
+
+Upgrade later with `brew upgrade --cask kiji-privacy-proxy`.
+
+**Manual download:**
+
 1. Download the latest DMG from [Releases](https://github.com/dataiku/kiji-proxy/releases)
 2. Open the DMG file
 3. Drag "Kiji Privacy Proxy" to Applications


### PR DESCRIPTION
## Problem

`brew install --cask dataiku/tap/kiji-privacy-proxy` fails — the tap repo `dataiku/homebrew-tap` contains only its `README.md`, no `Casks/`. The cask has **never** been published, despite every release running the `publish-homebrew-tap` job to success.

Root cause is in the "Render cask and push" step. It renders the cask to a brand-new file and then gates the commit on:

```bash
if git diff --quiet -- Casks/kiji-privacy-proxy.rb; then
  echo "::notice::Cask already at ${VERSION}, nothing to commit."
  exit 0
fi
```

`git diff --quiet -- <path>` only inspects **tracked** files. On the first publish the cask is untracked, so git reports no change, the step takes the early `exit 0`, and the `git add`/`commit`/`push` never run. It's chicken-and-egg: it will only commit a file that's already committed.

Confirmed in the v1.1.2 run — the cask rendered with `version "1.1.2"`, then:
```
##[notice]Cask already at 1.1.2, nothing to commit.
```

## Fix

Stage the file first, then check the staged diff against `HEAD`:

```bash
git add Casks/kiji-privacy-proxy.rb
if git diff --cached --quiet; then
  echo "::notice::Cask already at ${VERSION}, nothing to commit."
  exit 0
fi
git commit ...
git push ...
```

`git diff --cached --quiet` detects brand-new files as well as modifications, so the first publish commits the cask and subsequent runs stay idempotent.

## After this lands

The next release will populate the tap automatically. To unblock the **already-released v1.1.2** immediately without waiting, the tap can be seeded once by committing the rendered cask (version `1.1.2`, sha256 `bd6a9da0b68befaac6332adfe6f8229058cc5ce66b86b353120e374bb5e5efdc`) to `dataiku/homebrew-tap`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

## Docs (added in this PR)

Documented `brew install --cask dataiku/tap/kiji-privacy-proxy` as the recommended macOS install path in:
- `README.md` (Quick Start)
- `docs/01-getting-started.md` (Quick Installation)
- the generated GitHub Release notes (`release.yml`)

These instructions become functional once the tap is populated (after this fix ships on the next release, or via a one-time manual seed).
