### PR TITLE
fix: drop unsupported macOS floor from Homebrew cask

### DIFF
--- a/packaging/homebrew/Casks/kiji-privacy-proxy.rb
+++ b/packaging/homebrew/Casks/kiji-privacy-proxy.rb
@@ -13,8 +13,6 @@ cask "kiji-privacy-proxy" do
     strategy :github_latest
   end
 
-  depends_on macos: ">= :high_sierra"
-
   app "Kiji Privacy Proxy.app"
 
   zap trash: [


### PR DESCRIPTION
## Problem

`brew install --cask dataiku/tap/kiji-privacy-proxy` fails on current Homebrew:

```
Error: Calling `depends_on macos: :high_sierra` is disabled! There is no replacement.
  .../Casks/kiji-privacy-proxy.rb:16
```

The cask template uses `depends_on macos: ">= :high_sierra"`. Homebrew has **removed** the High Sierra (10.13) and Mojave (10.14) symbols from its known macOS versions, so the cask no longer loads. Verified against Homebrew 5.1.14: its `MacOSVersion::SYMBOLS` now bottoms out at `catalina` (10.15), and both `catalina` and `big_sur` are already flagged `odisabled` for removal in 2026/2027.

So **any** hard-coded macOS symbol is a recurring time-bomb — it re-breaks on every release re-render once Homebrew drops that version.

## Fix

Drop the `depends_on macos:` line. The real minimum (Electron 42 ⇒ macOS 11+) is enforced at runtime by the app and documented in the install guide; encoding it as a removable cask symbol just rots. Verified the cask loads cleanly with the line removed (`brew info --cask` succeeds).

If an explicit guard is later desired, use a currently-supported symbol, e.g. `depends_on macos: ">= :monterey"` (note: numeric strings like `">= 11"` are **not** accepted — Homebrew requires the symbol form).

## Note

The already-published v1.1.3 cask in `dataiku/homebrew-tap` was hot-patched directly to unblock installs now. This PR makes the **template** match so the next release re-renders correctly. Merge this before cutting the next release, otherwise the render reintroduces the broken line.

🤖 Generated with [Claude Code](https://claude.com/claude-code)