### PR TITLE
feat: endpoints to enable labels

### DIFF
--- a/src/backend/pii/detectors/detector.go
+++ b/src/backend/pii/detectors/detector.go
@@ -8,6 +8,10 @@ type Detector interface {
 	GetName() string
 	Detect(ctx context.Context, input DetectorInput) (DetectorOutput, error)
 	SetEntityConfidenceThreshold(threshold float64)
+	// EntityTypes returns the deduplicated set of base entity labels this model
+	// can emit (BIO prefixes stripped, non-entity sentinels O/IGNORE excluded),
+	// sorted alphabetically. This is the maximum set of selectable entities.
+	EntityTypes() []string
 	Close() error
 }
 

--- a/src/backend/pii/detectors/onnx_model_detector.go
+++ b/src/backend/pii/detectors/onnx_model_detector.go
@@ -237,6 +237,27 @@ func (d *ONNXModelDetectorSimple) SetEntityConfidenceThreshold(threshold float64
 	d.entityConfidenceThreshold = threshold
 }
 
+// EntityTypes returns the deduplicated, sorted set of base entity labels from the
+// loaded model's label map. BIO prefixes are stripped via splitBIOLabel and the
+// non-entity sentinels "O" and "IGNORE" are excluded.
+func (d *ONNXModelDetectorSimple) EntityTypes() []string {
+	seen := make(map[string]struct{})
+	for _, label := range d.id2label {
+		base, _, _ := splitBIOLabel(label)
+		if base == "O" || base == "IGNORE" {
+			continue
+		}
+		seen[base] = struct{}{}
+	}
+
+	types := make([]string, 0, len(seen))
+	for base := range seen {
+		types = append(types, base)
+	}
+	sort.Strings(types)
+	return types
+}
+
 // Detect processes the input and returns detected entities
 func (d *ONNXModelDetectorSimple) Detect(ctx context.Context, input DetectorInput) (DetectorOutput, error) {
 	// Initialize session and tensors on first use

--- a/src/backend/pii/masking_service.go
+++ b/src/backend/pii/masking_service.go
@@ -34,14 +34,15 @@ type MaskingService struct {
 	generator        *GeneratorService
 	mapping          *PIIMapping // optional persistent original<->dummy store; nil disables reuse
 
-	// enabledEntities is the set of base entity labels the user has chosen to
-	// mask. A nil map means "no selection has been made" and every detected
-	// entity is masked (default behavior). A non-nil map (even if empty) is an
-	// explicit selection: only labels present in it are masked. Guarded by mu so
-	// it can be updated at runtime via the settings API without recreating the
-	// service (the selection therefore survives model hot-reloads).
-	mu              sync.RWMutex
-	enabledEntities map[string]struct{}
+	// disabledEntities is the set of base entity labels the user has chosen NOT
+	// to mask (they pass through to the provider unchanged). This is an exclusion
+	// list on purpose: a nil or empty set means "nothing is excluded, mask
+	// everything", so the default — and any accidental clearing of the
+	// selection — fails closed toward masking rather than leaking PII. Guarded by
+	// mu so it can be updated at runtime via the settings API without recreating
+	// the service (the selection therefore survives model hot-reloads).
+	mu               sync.RWMutex
+	disabledEntities map[string]struct{}
 }
 
 // NewMaskingService creates a new masking service.
@@ -77,10 +78,10 @@ func (s *MaskingService) MaskText(text string, logPrefix string) MaskedResult {
 		}
 	}
 
-	// Drop entities whose type the user has deselected. Disabled types pass
-	// through unmasked. This runs before any masking so both the masked text and
-	// the returned Entities reflect only the active selection.
-	piiFound.Entities = s.filterEnabledEntities(piiFound.Entities)
+	// Drop entities whose type the user has disabled. Disabled types pass through
+	// unmasked. This runs before any masking so both the masked text and the
+	// returned Entities reflect only the active selection.
+	piiFound.Entities = s.filterDisabledEntities(piiFound.Entities)
 
 	if len(piiFound.Entities) == 0 {
 		log.Printf("%s No PII detected", logPrefix)
@@ -172,62 +173,52 @@ func (s *MaskingService) MaskText(text string, logPrefix string) MaskedResult {
 	}
 }
 
-// filterEnabledEntities removes entities whose base label is not in the active
-// selection. A nil selection means "mask everything" and the input is returned
-// unchanged.
-func (s *MaskingService) filterEnabledEntities(entities []detectors.Entity) []detectors.Entity {
+// filterDisabledEntities removes entities whose base label the user has disabled
+// (those pass through unmasked). An empty exclusion set means "nothing is
+// disabled", so everything is masked — the fail-closed default.
+func (s *MaskingService) filterDisabledEntities(entities []detectors.Entity) []detectors.Entity {
 	s.mu.RLock()
-	enabled := s.enabledEntities
+	disabled := s.disabledEntities
 	s.mu.RUnlock()
 
-	if enabled == nil {
+	if len(disabled) == 0 {
 		return entities
 	}
 
 	filtered := make([]detectors.Entity, 0, len(entities))
 	for _, e := range entities {
-		if _, ok := enabled[e.Label]; ok {
+		if _, ok := disabled[e.Label]; !ok {
 			filtered = append(filtered, e)
 		}
 	}
 	return filtered
 }
 
-// SetEnabledEntities sets the active selection of entity labels to mask. Passing
-// nil clears the selection (mask everything); passing a non-nil slice — even an
-// empty one — is an explicit selection (an empty slice masks nothing).
-func (s *MaskingService) SetEnabledEntities(labels []string) {
+// SetDisabledEntities sets the labels to leave unmasked. An empty (or nil) slice
+// clears the exclusion list, which means "mask everything" — so an accidental
+// empty selection fails closed toward masking rather than leaking PII.
+func (s *MaskingService) SetDisabledEntities(labels []string) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
-	if labels == nil {
-		s.enabledEntities = nil
+	if len(labels) == 0 {
+		s.disabledEntities = nil
 		return
 	}
 	set := make(map[string]struct{}, len(labels))
 	for _, label := range labels {
 		set[label] = struct{}{}
 	}
-	s.enabledEntities = set
+	s.disabledEntities = set
 }
 
-// GetEnabledEntities returns the sorted active selection of entity labels. When
-// no explicit selection has been made it returns the full set of available
-// entity types (so callers see "everything enabled").
-func (s *MaskingService) GetEnabledEntities() []string {
+// GetDisabledEntities returns the sorted set of labels currently left unmasked.
+// An empty result means everything is masked.
+func (s *MaskingService) GetDisabledEntities() []string {
 	s.mu.RLock()
-	enabled := s.enabledEntities
-	s.mu.RUnlock()
+	defer s.mu.RUnlock()
 
-	if enabled == nil {
-		available, err := s.GetAvailableEntityTypes()
-		if err != nil {
-			return []string{}
-		}
-		return available
-	}
-
-	labels := make([]string, 0, len(enabled))
-	for label := range enabled {
+	labels := make([]string, 0, len(s.disabledEntities))
+	for label := range s.disabledEntities {
 		labels = append(labels, label)
 	}
 	sort.Strings(labels)

--- a/src/backend/pii/masking_service.go
+++ b/src/backend/pii/masking_service.go
@@ -5,6 +5,7 @@ import (
 	"log"
 	"sort"
 	"strings"
+	"sync"
 
 	detectors "github.com/hannes/kiji-private/src/backend/pii/detectors"
 )
@@ -32,6 +33,15 @@ type MaskingService struct {
 	detectorProvider DetectorProvider
 	generator        *GeneratorService
 	mapping          *PIIMapping // optional persistent original<->dummy store; nil disables reuse
+
+	// enabledEntities is the set of base entity labels the user has chosen to
+	// mask. A nil map means "no selection has been made" and every detected
+	// entity is masked (default behavior). A non-nil map (even if empty) is an
+	// explicit selection: only labels present in it are masked. Guarded by mu so
+	// it can be updated at runtime via the settings API without recreating the
+	// service (the selection therefore survives model hot-reloads).
+	mu              sync.RWMutex
+	enabledEntities map[string]struct{}
 }
 
 // NewMaskingService creates a new masking service.
@@ -66,6 +76,11 @@ func (s *MaskingService) MaskText(text string, logPrefix string) MaskedResult {
 			Entities:         []detectors.Entity{},
 		}
 	}
+
+	// Drop entities whose type the user has deselected. Disabled types pass
+	// through unmasked. This runs before any masking so both the masked text and
+	// the returned Entities reflect only the active selection.
+	piiFound.Entities = s.filterEnabledEntities(piiFound.Entities)
 
 	if len(piiFound.Entities) == 0 {
 		log.Printf("%s No PII detected", logPrefix)
@@ -155,6 +170,78 @@ func (s *MaskingService) MaskText(text string, logPrefix string) MaskedResult {
 		MaskedToOriginal: maskedToOriginal,
 		Entities:         entities,
 	}
+}
+
+// filterEnabledEntities removes entities whose base label is not in the active
+// selection. A nil selection means "mask everything" and the input is returned
+// unchanged.
+func (s *MaskingService) filterEnabledEntities(entities []detectors.Entity) []detectors.Entity {
+	s.mu.RLock()
+	enabled := s.enabledEntities
+	s.mu.RUnlock()
+
+	if enabled == nil {
+		return entities
+	}
+
+	filtered := make([]detectors.Entity, 0, len(entities))
+	for _, e := range entities {
+		if _, ok := enabled[e.Label]; ok {
+			filtered = append(filtered, e)
+		}
+	}
+	return filtered
+}
+
+// SetEnabledEntities sets the active selection of entity labels to mask. Passing
+// nil clears the selection (mask everything); passing a non-nil slice — even an
+// empty one — is an explicit selection (an empty slice masks nothing).
+func (s *MaskingService) SetEnabledEntities(labels []string) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if labels == nil {
+		s.enabledEntities = nil
+		return
+	}
+	set := make(map[string]struct{}, len(labels))
+	for _, label := range labels {
+		set[label] = struct{}{}
+	}
+	s.enabledEntities = set
+}
+
+// GetEnabledEntities returns the sorted active selection of entity labels. When
+// no explicit selection has been made it returns the full set of available
+// entity types (so callers see "everything enabled").
+func (s *MaskingService) GetEnabledEntities() []string {
+	s.mu.RLock()
+	enabled := s.enabledEntities
+	s.mu.RUnlock()
+
+	if enabled == nil {
+		available, err := s.GetAvailableEntityTypes()
+		if err != nil {
+			return []string{}
+		}
+		return available
+	}
+
+	labels := make([]string, 0, len(enabled))
+	for label := range enabled {
+		labels = append(labels, label)
+	}
+	sort.Strings(labels)
+	return labels
+}
+
+// GetAvailableEntityTypes returns the maximum set of selectable entity labels,
+// sourced from the currently loaded model.
+func (s *MaskingService) GetAvailableEntityTypes() ([]string, error) {
+	detector, err := s.detectorProvider.GetDetector()
+	if err != nil {
+		return nil, err
+	}
+	return detector.EntityTypes(), nil
 }
 
 // RestorePII restores masked PII text back to original text using the stored mapping

--- a/src/backend/proxy/handler.go
+++ b/src/backend/proxy/handler.go
@@ -76,6 +76,31 @@ func (h *Handler) GetEntityConfidenceThreshold() float64 {
 	return h.modelManager.GetEntityConfidenceThreshold()
 }
 
+// SetEnabledEntities updates which entity types are masked. Passing nil clears
+// the selection (mask everything).
+func (h *Handler) SetEnabledEntities(labels []string) {
+	if h.maskingService != nil {
+		h.maskingService.SetEnabledEntities(labels)
+	}
+}
+
+// GetEnabledEntities returns the entity types currently selected for masking.
+func (h *Handler) GetEnabledEntities() []string {
+	if h.maskingService == nil {
+		return []string{}
+	}
+	return h.maskingService.GetEnabledEntities()
+}
+
+// GetAvailableEntityTypes returns the full set of entity types the loaded model
+// can detect (the maximum selectable set).
+func (h *Handler) GetAvailableEntityTypes() ([]string, error) {
+	if h.maskingService == nil {
+		return nil, fmt.Errorf("masking service not initialized")
+	}
+	return h.maskingService.GetAvailableEntityTypes()
+}
+
 // GetModelInfo returns information about the current model state
 func (h *Handler) GetModelInfo() map[string]interface{} {
 	if h.modelManager == nil {

--- a/src/backend/proxy/handler.go
+++ b/src/backend/proxy/handler.go
@@ -76,20 +76,20 @@ func (h *Handler) GetEntityConfidenceThreshold() float64 {
 	return h.modelManager.GetEntityConfidenceThreshold()
 }
 
-// SetEnabledEntities updates which entity types are masked. Passing nil clears
-// the selection (mask everything).
-func (h *Handler) SetEnabledEntities(labels []string) {
+// SetDisabledEntities updates which entity types are left unmasked. An empty
+// list clears the exclusion (mask everything).
+func (h *Handler) SetDisabledEntities(labels []string) {
 	if h.maskingService != nil {
-		h.maskingService.SetEnabledEntities(labels)
+		h.maskingService.SetDisabledEntities(labels)
 	}
 }
 
-// GetEnabledEntities returns the entity types currently selected for masking.
-func (h *Handler) GetEnabledEntities() []string {
+// GetDisabledEntities returns the entity types currently left unmasked.
+func (h *Handler) GetDisabledEntities() []string {
 	if h.maskingService == nil {
 		return []string{}
 	}
-	return h.maskingService.GetEnabledEntities()
+	return h.maskingService.GetDisabledEntities()
 }
 
 // GetAvailableEntityTypes returns the full set of entity types the loaded model

--- a/src/backend/proxy/handler_test.go
+++ b/src/backend/proxy/handler_test.go
@@ -22,12 +22,14 @@ import (
 
 // mockDetector implements pii.Detector for testing without ONNX model
 type mockDetector struct {
-	entities []pii.Entity
+	entities    []pii.Entity
+	entityTypes []string
 }
 
 func (d *mockDetector) GetName() string                        { return "mock" }
 func (d *mockDetector) Close() error                           { return nil }
 func (d *mockDetector) SetEntityConfidenceThreshold(_ float64) {}
+func (d *mockDetector) EntityTypes() []string                  { return d.entityTypes }
 func (d *mockDetector) Detect(_ context.Context, input pii.DetectorInput) (pii.DetectorOutput, error) {
 	return pii.DetectorOutput{
 		Text:     input.Text,
@@ -985,5 +987,76 @@ func TestHandler_MaskPIIInText_NoPII(t *testing.T) {
 	}
 	if len(entities) != 0 {
 		t.Errorf("expected empty entities, got %v", entities)
+	}
+}
+
+func TestHandler_MaskPIIInText_FilterDisabledEntities(t *testing.T) {
+	// "John a@b.com": FIRSTNAME at [0,4), EMAIL at [5,12).
+	detector := &mockDetector{
+		entities: []pii.Entity{
+			{Text: "John", Label: "FIRSTNAME", StartPos: 0, EndPos: 4, Confidence: 0.95},
+			{Text: "a@b.com", Label: "EMAIL", StartPos: 5, EndPos: 12, Confidence: 0.95},
+		},
+		entityTypes: []string{"EMAIL", "FIRSTNAME"},
+	}
+	h := newTestHandler(t, detector, nil)
+
+	// Only mask first names; email must pass through unmasked.
+	h.SetEnabledEntities([]string{"FIRSTNAME"})
+
+	maskedText, mapping, entities := h.maskPIIInText("John a@b.com", "[test]")
+
+	if len(entities) != 1 || entities[0].Label != "FIRSTNAME" {
+		t.Fatalf("expected only the FIRSTNAME entity, got %+v", entities)
+	}
+	if !strings.Contains(maskedText, "a@b.com") {
+		t.Errorf("expected disabled EMAIL to pass through unmasked, got %q", maskedText)
+	}
+	if strings.Contains(maskedText, "John") {
+		t.Errorf("expected FIRSTNAME to be masked, got %q", maskedText)
+	}
+	if len(mapping) != 1 {
+		t.Errorf("expected exactly one masked->original mapping, got %v", mapping)
+	}
+}
+
+func TestHandler_MaskPIIInText_DeselectAllMasksNothing(t *testing.T) {
+	detector := &mockDetector{
+		entities: []pii.Entity{
+			{Text: "John", Label: "FIRSTNAME", StartPos: 0, EndPos: 4, Confidence: 0.95},
+		},
+		entityTypes: []string{"FIRSTNAME"},
+	}
+	h := newTestHandler(t, detector, nil)
+
+	// An explicit empty selection (non-nil) means mask nothing.
+	h.SetEnabledEntities([]string{})
+
+	maskedText, mapping, entities := h.maskPIIInText("John here", "[test]")
+
+	if maskedText != "John here" {
+		t.Errorf("expected unchanged text when nothing is enabled, got %q", maskedText)
+	}
+	if len(mapping) != 0 || len(entities) != 0 {
+		t.Errorf("expected no masking, got mapping=%v entities=%v", mapping, entities)
+	}
+}
+
+func TestHandler_EntityTypeAccessors(t *testing.T) {
+	detector := &mockDetector{entityTypes: []string{"EMAIL", "FIRSTNAME"}}
+	h := newTestHandler(t, detector, nil)
+
+	available, err := h.GetAvailableEntityTypes()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(available) != 2 || available[0] != "EMAIL" || available[1] != "FIRSTNAME" {
+		t.Errorf("unexpected available types: %v", available)
+	}
+
+	// With no explicit selection, GetEnabledEntities reports everything available.
+	enabled := h.GetEnabledEntities()
+	if len(enabled) != 2 {
+		t.Errorf("expected all entities enabled by default, got %v", enabled)
 	}
 }

--- a/src/backend/proxy/handler_test.go
+++ b/src/backend/proxy/handler_test.go
@@ -990,7 +990,7 @@ func TestHandler_MaskPIIInText_NoPII(t *testing.T) {
 	}
 }
 
-func TestHandler_MaskPIIInText_FilterDisabledEntities(t *testing.T) {
+func TestHandler_MaskPIIInText_DisabledEntityPassesThrough(t *testing.T) {
 	// "John a@b.com": FIRSTNAME at [0,4), EMAIL at [5,12).
 	detector := &mockDetector{
 		entities: []pii.Entity{
@@ -1001,8 +1001,8 @@ func TestHandler_MaskPIIInText_FilterDisabledEntities(t *testing.T) {
 	}
 	h := newTestHandler(t, detector, nil)
 
-	// Only mask first names; email must pass through unmasked.
-	h.SetEnabledEntities([]string{"FIRSTNAME"})
+	// Disable EMAIL only; it must pass through unmasked while FIRSTNAME is masked.
+	h.SetDisabledEntities([]string{"EMAIL"})
 
 	maskedText, mapping, entities := h.maskPIIInText("John a@b.com", "[test]")
 
@@ -1020,7 +1020,9 @@ func TestHandler_MaskPIIInText_FilterDisabledEntities(t *testing.T) {
 	}
 }
 
-func TestHandler_MaskPIIInText_DeselectAllMasksNothing(t *testing.T) {
+func TestHandler_MaskPIIInText_EmptyDisabledMasksAll(t *testing.T) {
+	// The fail-closed property: an empty exclusion list masks everything, so an
+	// accidental cleared selection never leaks PII.
 	detector := &mockDetector{
 		entities: []pii.Entity{
 			{Text: "John", Label: "FIRSTNAME", StartPos: 0, EndPos: 4, Confidence: 0.95},
@@ -1029,16 +1031,15 @@ func TestHandler_MaskPIIInText_DeselectAllMasksNothing(t *testing.T) {
 	}
 	h := newTestHandler(t, detector, nil)
 
-	// An explicit empty selection (non-nil) means mask nothing.
-	h.SetEnabledEntities([]string{})
+	h.SetDisabledEntities([]string{}) // explicit empty => mask everything
 
 	maskedText, mapping, entities := h.maskPIIInText("John here", "[test]")
 
-	if maskedText != "John here" {
-		t.Errorf("expected unchanged text when nothing is enabled, got %q", maskedText)
+	if strings.Contains(maskedText, "John") {
+		t.Errorf("expected FIRSTNAME to be masked when nothing is disabled, got %q", maskedText)
 	}
-	if len(mapping) != 0 || len(entities) != 0 {
-		t.Errorf("expected no masking, got mapping=%v entities=%v", mapping, entities)
+	if len(mapping) != 1 || len(entities) != 1 {
+		t.Errorf("expected one entity masked, got mapping=%v entities=%v", mapping, entities)
 	}
 }
 
@@ -1054,9 +1055,9 @@ func TestHandler_EntityTypeAccessors(t *testing.T) {
 		t.Errorf("unexpected available types: %v", available)
 	}
 
-	// With no explicit selection, GetEnabledEntities reports everything available.
-	enabled := h.GetEnabledEntities()
-	if len(enabled) != 2 {
-		t.Errorf("expected all entities enabled by default, got %v", enabled)
+	// With no explicit selection, nothing is disabled (everything is masked).
+	disabled := h.GetDisabledEntities()
+	if len(disabled) != 0 {
+		t.Errorf("expected no disabled entities by default, got %v", disabled)
 	}
 }

--- a/src/backend/server/server.go
+++ b/src/backend/server/server.go
@@ -21,6 +21,7 @@ import (
 
 const responseFieldSuccess = "success"
 const responseFieldEnabled = "enabled"
+const responseFieldDisabled = "disabled"
 
 // RateLimiter manages rate limiting for API endpoints
 type RateLimiter struct {
@@ -737,8 +738,9 @@ func (s *Server) handlePIIConfidence(w http.ResponseWriter, r *http.Request) {
 }
 
 // handlePIIEntities handles GET/POST /api/pii/entities requests. GET returns the
-// available entity types (from the loaded model) plus the currently enabled
-// selection. POST replaces the enabled selection with the provided list.
+// available entity types (from the loaded model) plus the entity types currently
+// disabled (left unmasked). POST replaces the disabled set with the provided
+// list; an empty list means "mask everything" (fail closed).
 func (s *Server) handlePIIEntities(w http.ResponseWriter, r *http.Request) {
 	s.corsHandler(w, r)
 
@@ -756,15 +758,15 @@ func (s *Server) handlePIIEntities(w http.ResponseWriter, r *http.Request) {
 		}
 		w.Header().Set("Content-Type", "application/json")
 		if err := json.NewEncoder(w).Encode(map[string]interface{}{
-			"available":          available,
-			responseFieldEnabled: s.handler.GetEnabledEntities(),
+			"available":           available,
+			responseFieldDisabled: s.handler.GetDisabledEntities(),
 		}); err != nil {
 			log.Printf("Failed to encode PII entities response: %v", err)
 		}
 
 	case http.MethodPost:
 		var req struct {
-			Enabled []string `json:"enabled"`
+			Disabled []string `json:"disabled"`
 		}
 		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
 			http.Error(w, "Invalid request", http.StatusBadRequest)
@@ -779,7 +781,7 @@ func (s *Server) handlePIIEntities(w http.ResponseWriter, r *http.Request) {
 			for _, label := range available {
 				valid[label] = struct{}{}
 			}
-			for _, label := range req.Enabled {
+			for _, label := range req.Disabled {
 				if _, ok := valid[label]; !ok {
 					http.Error(w, "Unknown entity label: "+label, http.StatusBadRequest)
 					return
@@ -787,13 +789,13 @@ func (s *Server) handlePIIEntities(w http.ResponseWriter, r *http.Request) {
 			}
 		}
 
-		s.handler.SetEnabledEntities(req.Enabled)
-		log.Printf("PII enabled entities updated: %d selected", len(req.Enabled))
+		s.handler.SetDisabledEntities(req.Disabled)
+		log.Printf("PII disabled (passthrough) entities updated: %d left unmasked", len(req.Disabled))
 
 		w.Header().Set("Content-Type", "application/json")
 		if err := json.NewEncoder(w).Encode(map[string]interface{}{
-			responseFieldSuccess: true,
-			responseFieldEnabled: req.Enabled,
+			responseFieldSuccess:  true,
+			responseFieldDisabled: req.Disabled,
 		}); err != nil {
 			log.Printf("Failed to encode PII entities response: %v", err)
 		}

--- a/src/backend/server/server.go
+++ b/src/backend/server/server.go
@@ -20,6 +20,7 @@ import (
 )
 
 const responseFieldSuccess = "success"
+const responseFieldEnabled = "enabled"
 
 // RateLimiter manages rate limiting for API endpoints
 type RateLimiter struct {
@@ -755,8 +756,8 @@ func (s *Server) handlePIIEntities(w http.ResponseWriter, r *http.Request) {
 		}
 		w.Header().Set("Content-Type", "application/json")
 		if err := json.NewEncoder(w).Encode(map[string]interface{}{
-			"available": available,
-			"enabled":   s.handler.GetEnabledEntities(),
+			"available":          available,
+			responseFieldEnabled: s.handler.GetEnabledEntities(),
 		}); err != nil {
 			log.Printf("Failed to encode PII entities response: %v", err)
 		}
@@ -792,7 +793,7 @@ func (s *Server) handlePIIEntities(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 		if err := json.NewEncoder(w).Encode(map[string]interface{}{
 			responseFieldSuccess: true,
-			"enabled":            req.Enabled,
+			responseFieldEnabled: req.Enabled,
 		}); err != nil {
 			log.Printf("Failed to encode PII entities response: %v", err)
 		}
@@ -834,7 +835,7 @@ func (s *Server) handleTransparentProxyToggle(w http.ResponseWriter, r *http.Req
 	w.WriteHeader(http.StatusOK)
 	response := map[string]interface{}{
 		responseFieldSuccess: true,
-		"enabled":            req.Enabled,
+		responseFieldEnabled: req.Enabled,
 	}
 	if err := json.NewEncoder(w).Encode(response); err != nil {
 		log.Printf("Failed to encode response: %v", err)

--- a/src/backend/server/server.go
+++ b/src/backend/server/server.go
@@ -241,6 +241,7 @@ func (s *Server) Start() error {
 	mux.HandleFunc("/api/proxy/transparent/toggle", s.handleTransparentProxyToggle)
 	mux.HandleFunc("/api/pii/check", s.handlePIICheck)
 	mux.HandleFunc("/api/pii/confidence", s.handlePIIConfidence)
+	mux.HandleFunc("/api/pii/entities", s.handlePIIEntities)
 
 	// Add provider endpoints
 	mux.Handle(providers.ProviderSubpathOpenAI, s.handler) // same as Mistral
@@ -370,6 +371,8 @@ func (s *Server) startTransparentProxy() {
 			s.handlePIICheck(w, r)
 		case "/api/pii/confidence":
 			s.handlePIIConfidence(w, r)
+		case "/api/pii/entities":
+			s.handlePIIEntities(w, r)
 		default:
 			// All other HTTP/HTTPS requests go to transparent proxy
 			s.transparentProxy.ServeHTTP(w, r)
@@ -725,6 +728,73 @@ func (s *Server) handlePIIConfidence(w http.ResponseWriter, r *http.Request) {
 			"confidence":         req.Confidence,
 		}); err != nil {
 			log.Printf("Failed to encode PII confidence response: %v", err)
+		}
+
+	default:
+		http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
+	}
+}
+
+// handlePIIEntities handles GET/POST /api/pii/entities requests. GET returns the
+// available entity types (from the loaded model) plus the currently enabled
+// selection. POST replaces the enabled selection with the provided list.
+func (s *Server) handlePIIEntities(w http.ResponseWriter, r *http.Request) {
+	s.corsHandler(w, r)
+
+	if r.Method == http.MethodOptions {
+		w.WriteHeader(http.StatusOK)
+		return
+	}
+
+	switch r.Method {
+	case http.MethodGet:
+		available, err := s.handler.GetAvailableEntityTypes()
+		if err != nil {
+			http.Error(w, "Model not available", http.StatusServiceUnavailable)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		if err := json.NewEncoder(w).Encode(map[string]interface{}{
+			"available": available,
+			"enabled":   s.handler.GetEnabledEntities(),
+		}); err != nil {
+			log.Printf("Failed to encode PII entities response: %v", err)
+		}
+
+	case http.MethodPost:
+		var req struct {
+			Enabled []string `json:"enabled"`
+		}
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			http.Error(w, "Invalid request", http.StatusBadRequest)
+			return
+		}
+
+		// Reject labels the loaded model can't produce so the selection stays
+		// meaningful. If the model is unavailable we skip validation rather than
+		// drop the user's choice.
+		if available, err := s.handler.GetAvailableEntityTypes(); err == nil {
+			valid := make(map[string]struct{}, len(available))
+			for _, label := range available {
+				valid[label] = struct{}{}
+			}
+			for _, label := range req.Enabled {
+				if _, ok := valid[label]; !ok {
+					http.Error(w, "Unknown entity label: "+label, http.StatusBadRequest)
+					return
+				}
+			}
+		}
+
+		s.handler.SetEnabledEntities(req.Enabled)
+		log.Printf("PII enabled entities updated: %d selected", len(req.Enabled))
+
+		w.Header().Set("Content-Type", "application/json")
+		if err := json.NewEncoder(w).Encode(map[string]interface{}{
+			responseFieldSuccess: true,
+			"enabled":            req.Enabled,
+		}); err != nil {
+			log.Printf("Failed to encode PII entities response: %v", err)
 		}
 
 	default:

--- a/src/frontend/src/components/modals/AdvancedSettingsModal.tsx
+++ b/src/frontend/src/components/modals/AdvancedSettingsModal.tsx
@@ -110,19 +110,17 @@ export default function AdvancedSettingsModal({
     if (!window.electronAPI) return;
 
     try {
-      const [info, savedEnabled] = await Promise.all([
+      const [info, savedDisabled] = await Promise.all([
         window.electronAPI.getAvailableEntities(),
-        window.electronAPI.getEnabledEntities(),
+        window.electronAPI.getDisabledEntities(),
       ]);
       const available = info?.available ?? [];
       setAvailableEntities(available);
-      // No saved selection => default to everything enabled. Otherwise keep only
-      // saved labels the currently loaded model still supports.
-      const enabled =
-        savedEnabled == null
-          ? new Set(available)
-          : new Set(savedEnabled.filter((e) => available.includes(e)));
-      setEnabledEntities(enabled);
+      // The stored value is the exclusion list (types left unmasked). A checkbox
+      // is checked when its type is NOT excluded, so the default (nothing
+      // excluded) shows everything checked => mask everything.
+      const disabled = new Set(savedDisabled ?? []);
+      setEnabledEntities(new Set(available.filter((e) => !disabled.has(e))));
     } catch (error) {
       console.error("Error loading entities:", error);
     }
@@ -173,12 +171,15 @@ export default function AdvancedSettingsModal({
     if (!window.electronAPI) return;
 
     setEnabledEntities(next);
+    // Persist the inverse — the exclusion list of types to leave unmasked — so an
+    // empty selection means "mask everything" and never leaks PII by accident.
+    const disabled = availableEntities.filter((label) => !next.has(label));
     try {
-      await window.electronAPI.setEnabledEntities([...next]);
+      await window.electronAPI.setDisabledEntities(disabled);
       setEntitiesSaved(true);
       setTimeout(() => setEntitiesSaved(false), 2000);
     } catch (error) {
-      console.error("Error saving enabled entities:", error);
+      console.error("Error saving entity selection:", error);
     }
   };
 

--- a/src/frontend/src/components/modals/AdvancedSettingsModal.tsx
+++ b/src/frontend/src/components/modals/AdvancedSettingsModal.tsx
@@ -1,5 +1,12 @@
 import { useState, useEffect } from "react";
-import { X, Server, FolderOpen, Shield, AlertTriangle } from "lucide-react";
+import {
+  X,
+  Server,
+  FolderOpen,
+  Shield,
+  AlertTriangle,
+  ListChecks,
+} from "lucide-react";
 import CACertSetupModal from "./CACertSetupModal";
 import { isElectron } from "../../utils/providerHelpers";
 
@@ -7,6 +14,41 @@ interface AdvancedSettingsModalProps {
   isOpen: boolean;
   onClose: () => void;
 }
+
+// Friendly display names for the model's raw entity labels. Unknown labels
+// (e.g. from a custom model) fall back to a capitalized form.
+const ENTITY_LABEL_NAMES: Record<string, string> = {
+  SURNAME: "Surname",
+  FIRSTNAME: "First Name",
+  BUILDINGNUM: "Building Number",
+  DATEOFBIRTH: "Date of Birth",
+  EMAIL: "Email",
+  PHONENUMBER: "Phone Number",
+  CITY: "City",
+  URL: "URL",
+  COMPANYNAME: "Company Name",
+  STATE: "State",
+  ZIP: "ZIP Code",
+  STREET: "Street",
+  COUNTRY: "Country",
+  SSN: "SSN",
+  DRIVERLICENSENUM: "Driver License Number",
+  PASSPORTID: "Passport ID",
+  NATIONALID: "National ID",
+  IDCARDNUM: "ID Card Number",
+  TAXNUM: "Tax Number",
+  LICENSEPLATENUM: "License Plate Number",
+  PASSWORD: "Password",
+  IBAN: "IBAN",
+  AGE: "Age",
+  SECURITYTOKEN: "Security Token",
+  CREDITCARDNUMBER: "Credit Card Number",
+  USERNAME: "Username",
+};
+
+const humanizeEntity = (label: string): string =>
+  ENTITY_LABEL_NAMES[label] ??
+  label.charAt(0).toUpperCase() + label.slice(1).toLowerCase();
 
 export default function AdvancedSettingsModal({
   isOpen,
@@ -35,6 +77,13 @@ export default function AdvancedSettingsModal({
   const [entityConfidence, setEntityConfidence] = useState(0.25);
   const [confidenceSaved, setConfidenceSaved] = useState(false);
 
+  // Entities-to-mask state
+  const [availableEntities, setAvailableEntities] = useState<string[]>([]);
+  const [enabledEntities, setEnabledEntities] = useState<Set<string>>(
+    new Set()
+  );
+  const [entitiesSaved, setEntitiesSaved] = useState(false);
+
   const loadTransparentProxySetting = async () => {
     if (!window.electronAPI) return;
 
@@ -54,6 +103,28 @@ export default function AdvancedSettingsModal({
       setEntityConfidence(confidence);
     } catch (error) {
       console.error("Error loading entity confidence:", error);
+    }
+  };
+
+  const loadEntities = async () => {
+    if (!window.electronAPI) return;
+
+    try {
+      const [info, savedEnabled] = await Promise.all([
+        window.electronAPI.getAvailableEntities(),
+        window.electronAPI.getEnabledEntities(),
+      ]);
+      const available = info?.available ?? [];
+      setAvailableEntities(available);
+      // No saved selection => default to everything enabled. Otherwise keep only
+      // saved labels the currently loaded model still supports.
+      const enabled =
+        savedEnabled == null
+          ? new Set(available)
+          : new Set(savedEnabled.filter((e) => available.includes(e)));
+      setEnabledEntities(enabled);
+    } catch (error) {
+      console.error("Error loading entities:", error);
     }
   };
 
@@ -80,6 +151,7 @@ export default function AdvancedSettingsModal({
       loadModelInfo();
       loadTransparentProxySetting();
       loadEntityConfidence();
+      loadEntities();
       /* eslint-enable react-hooks/set-state-in-effect */
     }
   }, [isOpen]);
@@ -96,6 +168,34 @@ export default function AdvancedSettingsModal({
       console.error("Error setting entity confidence:", error);
     }
   };
+
+  const persistEnabledEntities = async (next: Set<string>) => {
+    if (!window.electronAPI) return;
+
+    setEnabledEntities(next);
+    try {
+      await window.electronAPI.setEnabledEntities([...next]);
+      setEntitiesSaved(true);
+      setTimeout(() => setEntitiesSaved(false), 2000);
+    } catch (error) {
+      console.error("Error saving enabled entities:", error);
+    }
+  };
+
+  const handleToggleEntity = (label: string) => {
+    const next = new Set(enabledEntities);
+    if (next.has(label)) {
+      next.delete(label);
+    } else {
+      next.add(label);
+    }
+    persistEnabledEntities(next);
+  };
+
+  const handleSelectAllEntities = () =>
+    persistEnabledEntities(new Set(availableEntities));
+
+  const handleDeselectAllEntities = () => persistEnabledEntities(new Set());
 
   const handleToggleTransparentProxy = async () => {
     if (!window.electronAPI) return;
@@ -301,6 +401,67 @@ export default function AdvancedSettingsModal({
               but may miss some PII.
             </p>
             {confidenceSaved && (
+              <p className="text-xs text-green-600 mt-1">Setting saved.</p>
+            )}
+          </div>
+
+          {/* Entities to Mask */}
+          <div>
+            <div className="flex items-center justify-between mb-2">
+              <label className="block text-sm font-semibold text-slate-700 flex items-center gap-2">
+                <ListChecks className="w-4 h-4" />
+                Entities to Mask
+              </label>
+              <div className="flex items-center gap-2 text-xs">
+                <button
+                  onClick={handleSelectAllEntities}
+                  disabled={availableEntities.length === 0}
+                  className="text-blue-600 hover:text-blue-800 disabled:opacity-40 disabled:cursor-not-allowed"
+                >
+                  Select all
+                </button>
+                <span className="text-slate-300">|</span>
+                <button
+                  onClick={handleDeselectAllEntities}
+                  disabled={availableEntities.length === 0}
+                  className="text-blue-600 hover:text-blue-800 disabled:opacity-40 disabled:cursor-not-allowed"
+                >
+                  Deselect all
+                </button>
+              </div>
+            </div>
+
+            {availableEntities.length === 0 ? (
+              <p className="text-xs text-slate-500">
+                No entity types available. Load a healthy PII model to configure
+                masking.
+              </p>
+            ) : (
+              <div className="grid grid-cols-2 gap-1 max-h-56 overflow-y-auto border-2 border-slate-200 rounded-lg p-2">
+                {availableEntities.map((label) => (
+                  <label
+                    key={label}
+                    className="flex items-center gap-2 px-2 py-1 rounded hover:bg-slate-50 cursor-pointer"
+                  >
+                    <input
+                      type="checkbox"
+                      checked={enabledEntities.has(label)}
+                      onChange={() => handleToggleEntity(label)}
+                      className="rounded border-slate-300 text-blue-600 focus:ring-blue-500"
+                    />
+                    <span className="text-sm text-slate-700">
+                      {humanizeEntity(label)}
+                    </span>
+                  </label>
+                ))}
+              </div>
+            )}
+
+            <p className="text-xs text-slate-500 mt-2">
+              Unchecked types are left unmasked and sent to the AI provider
+              as-is.
+            </p>
+            {entitiesSaved && (
               <p className="text-xs text-green-600 mt-1">Setting saved.</p>
             )}
           </div>

--- a/src/frontend/src/electron/electron-preload.js
+++ b/src/frontend/src/electron/electron-preload.js
@@ -182,16 +182,17 @@ contextBridge.exposeInMainWorld("electronAPI", {
     return await ipcRenderer.invoke("set-entity-confidence", confidence);
   },
 
-  // PII entities to mask
+  // PII entities to mask. The stored value is the exclusion list (types left
+  // unmasked); empty means "mask everything".
   getAvailableEntities: async () => {
     return await ipcRenderer.invoke("get-available-entities");
   },
 
-  getEnabledEntities: async () => {
-    return await ipcRenderer.invoke("get-enabled-entities");
+  getDisabledEntities: async () => {
+    return await ipcRenderer.invoke("get-disabled-entities");
   },
 
-  setEnabledEntities: async (entities) => {
-    return await ipcRenderer.invoke("set-enabled-entities", entities);
+  setDisabledEntities: async (entities) => {
+    return await ipcRenderer.invoke("set-disabled-entities", entities);
   },
 });

--- a/src/frontend/src/electron/electron-preload.js
+++ b/src/frontend/src/electron/electron-preload.js
@@ -181,4 +181,17 @@ contextBridge.exposeInMainWorld("electronAPI", {
   setEntityConfidence: async (confidence) => {
     return await ipcRenderer.invoke("set-entity-confidence", confidence);
   },
+
+  // PII entities to mask
+  getAvailableEntities: async () => {
+    return await ipcRenderer.invoke("get-available-entities");
+  },
+
+  getEnabledEntities: async () => {
+    return await ipcRenderer.invoke("get-enabled-entities");
+  },
+
+  setEnabledEntities: async (entities) => {
+    return await ipcRenderer.invoke("set-enabled-entities", entities);
+  },
 });

--- a/src/frontend/src/electron/electron.d.ts
+++ b/src/frontend/src/electron/electron.d.ts
@@ -93,6 +93,17 @@ interface ElectronAPI {
     confidence: number
   ) => Promise<{ success: boolean; error?: string }>;
 
+  // PII entities to mask
+  getAvailableEntities: () => Promise<{
+    available?: string[];
+    enabled?: string[];
+    error?: string;
+  }>;
+  getEnabledEntities: () => Promise<string[] | null>;
+  setEnabledEntities: (
+    entities: string[]
+  ) => Promise<{ success: boolean; error?: string }>;
+
   // Platform and version info
   platform: string;
   versions: {

--- a/src/frontend/src/electron/electron.d.ts
+++ b/src/frontend/src/electron/electron.d.ts
@@ -93,14 +93,15 @@ interface ElectronAPI {
     confidence: number
   ) => Promise<{ success: boolean; error?: string }>;
 
-  // PII entities to mask
+  // PII entities to mask. The stored value is the exclusion list (types left
+  // unmasked); empty means "mask everything".
   getAvailableEntities: () => Promise<{
     available?: string[];
-    enabled?: string[];
+    disabled?: string[];
     error?: string;
   }>;
-  getEnabledEntities: () => Promise<string[] | null>;
-  setEnabledEntities: (
+  getDisabledEntities: () => Promise<string[] | null>;
+  setDisabledEntities: (
     entities: string[]
   ) => Promise<{ success: boolean; error?: string }>;
 

--- a/src/frontend/src/electron/ipc-handlers.js
+++ b/src/frontend/src/electron/ipc-handlers.js
@@ -499,16 +499,18 @@ const registerIpcHandlers = ({
   );
 
   // ---- PII Entities to Mask ----
-  // Persist the user's selection of which entity types to mask and push it to
-  // the backend on change. null/unset means "mask everything" (the default).
+  // Persist the exclusion list — the entity types to leave UNMASKED — and push
+  // it to the backend on change. Storing the exclusion (rather than the masked
+  // set) is deliberate: null/empty means "nothing excluded, mask everything", so
+  // the default and any accidental clearing fail closed toward masking.
   defineConfigField(
-    "enabledEntities",
-    "get-enabled-entities",
-    "set-enabled-entities",
+    "disabledEntities",
+    "get-disabled-entities",
+    "set-disabled-entities",
     {
       defaultValue: null,
-      onChange: (enabled) =>
-        notifyBackendBestEffort("/api/pii/entities", { enabled }),
+      onChange: (disabled) =>
+        notifyBackendBestEffort("/api/pii/entities", { disabled }),
     }
   );
 

--- a/src/frontend/src/electron/ipc-handlers.js
+++ b/src/frontend/src/electron/ipc-handlers.js
@@ -497,6 +497,31 @@ const registerIpcHandlers = ({
         notifyBackendBestEffort("/api/pii/confidence", { confidence }),
     }
   );
+
+  // ---- PII Entities to Mask ----
+  // Persist the user's selection of which entity types to mask and push it to
+  // the backend on change. null/unset means "mask everything" (the default).
+  defineConfigField(
+    "enabledEntities",
+    "get-enabled-entities",
+    "set-enabled-entities",
+    {
+      defaultValue: null,
+      onChange: (enabled) =>
+        notifyBackendBestEffort("/api/pii/entities", { enabled }),
+    }
+  );
+
+  // The full set of selectable entity types comes from the loaded model, so it
+  // is read live from the backend rather than persisted in the config.
+  ipcMain.handle("get-available-entities", async () => {
+    try {
+      return await backendRequest("GET", "/api/pii/entities");
+    } catch (error) {
+      console.error("Error getting available entities:", error);
+      return { error: error.message };
+    }
+  });
 };
 
 module.exports = { registerIpcHandlers };


### PR DESCRIPTION
## Description

If disabled, entites will not be masked.

Normal state:

<img width="486" height="809" alt="Screenshot 2026-06-04 at 4 13 14 PM" src="https://github.com/user-attachments/assets/a2580c9d-eaae-42da-9d7b-a867f545d8ac" />
<img width="783" height="503" alt="Screenshot 2026-06-04 at 4 12 58 PM" src="https://github.com/user-attachments/assets/7f668cb3-6a3e-44a6-9b8b-8fc1835b999b" />

Disabled state:


<img width="791" height="594" alt="Screenshot 2026-06-04 at 4 13 40 PM" src="https://github.com/user-attachments/assets/8a32e190-e964-422a-b9a9-3c72688c0137" />
<img width="481" height="801" alt="Screenshot 2026-06-04 at 4 13 30 PM" src="https://github.com/user-attachments/assets/1c5cfb35-98ca-4bc4-a907-7e46540fbcbc" />


## Linked Issue

Closes #

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor / code quality
- [ ] Documentation update
- [ ] CI / build change

## Testing Done

<!-- Describe how you tested the changes. Include commands run and results observed. -->

**Unit tests (Go):**
```
make test-go
```

**Unit tests (Python):**
```
make test
```

**Linting & type checks:**
```
make lint
make typecheck
```

**Manual testing (if applicable):**
- Describe the scenario tested (e.g. PII type detected, proxy request flow, Chrome extension behavior)
- Include before/after behavior if fixing a bug
- Note any edge cases verified (e.g. nested PII in JSON payloads, restoration accuracy)

## Checklist

- [ ] `make test-go` and `make test` pass locally
- [ ] `make lint` reports no new errors
- [ ] New PII detection changes are covered by unit tests in `tests/`
- [ ] Go proxy changes include test coverage in `src/` or `model/`
- [ ] Documentation updated if behavior or configuration changed
- [ ] No sensitive data or credentials included
