### PR TITLE
fix: save pii config in pii_settings.json

### DIFF
--- a/src/backend/config/config.go
+++ b/src/backend/config/config.go
@@ -108,6 +108,10 @@ type Config struct {
 	// entry pairs a name (used as the detected entity type) with a regular
 	// expression. Empty means no custom regex detection.
 	CustomRegexes []RegexPatternConfig `json:"custom_regexes"`
+	// DisabledEntities is the set of entity labels the user has chosen to leave
+	// UNMASKED. Empty/nil means "mask everything" (fail closed). Persisted via
+	// pii_settings.json and reapplied at startup (see PIISettings).
+	DisabledEntities []string `json:"disabled_entities"`
 }
 
 // ModelVariantTrained is the full-precision model variant.
@@ -305,8 +309,9 @@ func DefaultConfig() *Config {
 			KeyPath:            keyPath,
 			EnablePAC:          true, // Enable PAC by default for automatic proxy configuration
 		},
-		Detectors:     DefaultDetectors(),
-		CustomRegexes: []RegexPatternConfig{},
+		Detectors:        DefaultDetectors(),
+		CustomRegexes:    []RegexPatternConfig{},
+		DisabledEntities: []string{},
 	}
 }
 

--- a/src/backend/config/pii_settings.go
+++ b/src/backend/config/pii_settings.go
@@ -1,0 +1,68 @@
+package config
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/hannes/kiji-private/src/backend/paths"
+)
+
+// PIISettingsFileName is the name of the file holding the runtime-tunable PII
+// settings, stored in the application data directory next to the database/certs.
+const PIISettingsFileName = "pii_settings.json"
+
+// PIISettings is the subset of PII configuration that the settings UI can change
+// at runtime (via the POST endpoints) and that must survive restarts. It is
+// persisted separately from the static --config file so the two never collide.
+type PIISettings struct {
+	DisabledEntities []string             `json:"disabled_entities"`
+	CustomRegexes    []RegexPatternConfig `json:"custom_regexes"`
+}
+
+// PIISettingsPath returns the absolute path to the persisted PII settings file.
+func PIISettingsPath() string {
+	return filepath.Join(paths.AppDataDir(), PIISettingsFileName)
+}
+
+// LoadPIISettings reads the persisted PII settings. It returns (nil, nil) when
+// the file does not exist yet (first run), so callers fall back to config
+// defaults. A malformed file is reported as an error rather than silently reset.
+func LoadPIISettings() (*PIISettings, error) {
+	path := PIISettingsPath()
+	data, err := os.ReadFile(path) // #nosec G304 — path derived from app data dir, not user input
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("read %s: %w", path, err)
+	}
+	var s PIISettings
+	if err := json.Unmarshal(data, &s); err != nil {
+		return nil, fmt.Errorf("parse %s: %w", path, err)
+	}
+	return &s, nil
+}
+
+// SavePIISettings writes the PII settings to disk, creating the application data
+// directory if needed. It writes to a temp file and renames so a crash mid-write
+// can't leave a truncated file.
+func SavePIISettings(s *PIISettings) error {
+	path := PIISettingsPath()
+	if err := os.MkdirAll(filepath.Dir(path), 0o750); err != nil {
+		return fmt.Errorf("create data dir for %s: %w", path, err)
+	}
+	data, err := json.MarshalIndent(s, "", "  ")
+	if err != nil {
+		return fmt.Errorf("marshal PII settings: %w", err)
+	}
+	tmp := path + ".tmp"
+	if err := os.WriteFile(tmp, data, 0o600); err != nil {
+		return fmt.Errorf("write %s: %w", tmp, err)
+	}
+	if err := os.Rename(tmp, path); err != nil {
+		return fmt.Errorf("rename %s -> %s: %w", tmp, path, err)
+	}
+	return nil
+}

--- a/src/backend/main.go
+++ b/src/backend/main.go
@@ -90,6 +90,18 @@ func run(configPath *string) error {
 	loadConfigFromEnv(cfg)
 	expandConfigPaths(cfg)
 
+	// Overlay PII settings the UI persisted via the POST endpoints (custom regexes
+	// and disabled labels). These are the user's latest runtime choices, so they
+	// take precedence over the config defaults and survive restarts.
+	if settings, err := config.LoadPIISettings(); err != nil {
+		log.Printf("Failed to load persisted PII settings, using config defaults: %v", err)
+	} else if settings != nil {
+		cfg.CustomRegexes = settings.CustomRegexes
+		cfg.DisabledEntities = settings.DisabledEntities
+		log.Printf("Loaded persisted PII settings: %d custom regex(es), %d disabled label(s)",
+			len(settings.CustomRegexes), len(settings.DisabledEntities))
+	}
+
 	if err := cfg.ValidateConfig(); err != nil {
 		return err
 	}

--- a/src/backend/proxy/handler.go
+++ b/src/backend/proxy/handler.go
@@ -778,6 +778,9 @@ func NewHandler(cfg *config.Config) (*Handler, error) {
 	generatorService := piiServices.NewGeneratorService()
 	piiMapping := piiServices.NewPIIMappingWithDB(db, true)
 	maskingService := piiServices.NewMaskingService(modelManager, generatorService, piiMapping)
+	// Seed the disabled (passthrough) entity labels persisted from a previous run.
+	// Empty/nil leaves everything masked (fail closed).
+	maskingService.SetDisabledEntities(cfg.DisabledEntities)
 
 	var responseProcessor *processor.ResponseProcessor
 	if detector != nil {

--- a/src/backend/server/server.go
+++ b/src/backend/server/server.go
@@ -748,6 +748,19 @@ func (s *Server) handlePIIConfidence(w http.ResponseWriter, r *http.Request) {
 	}
 }
 
+// savePIISettings snapshots the current disabled labels and custom regexes from
+// the handler and persists them to pii_settings.json so they survive restarts.
+// A persistence failure is logged but not surfaced to the caller — the in-memory
+// update has already taken effect; only durability across restarts is lost.
+func (s *Server) savePIISettings() {
+	if err := config.SavePIISettings(&config.PIISettings{
+		DisabledEntities: s.handler.GetDisabledEntities(),
+		CustomRegexes:    s.handler.GetCustomRegexes(),
+	}); err != nil {
+		log.Printf("Failed to persist PII settings to %s: %v", config.PIISettingsPath(), err)
+	}
+}
+
 // handlePIIEntities handles GET/POST /api/pii/entities requests. GET returns the
 // available entity types (from the loaded model) plus the entity types currently
 // disabled (left unmasked). POST replaces the disabled set with the provided
@@ -801,6 +814,7 @@ func (s *Server) handlePIIEntities(w http.ResponseWriter, r *http.Request) {
 		}
 
 		s.handler.SetDisabledEntities(req.Disabled)
+		s.savePIISettings()
 		log.Printf("PII disabled (passthrough) entities updated: %d left unmasked", len(req.Disabled))
 
 		w.Header().Set("Content-Type", "application/json")
@@ -850,6 +864,7 @@ func (s *Server) handlePIIRegexes(w http.ResponseWriter, r *http.Request) {
 			http.Error(w, err.Error(), http.StatusBadRequest)
 			return
 		}
+		s.savePIISettings()
 		log.Printf("PII custom regexes updated: %d pattern(s)", len(req.Regexes))
 
 		w.Header().Set("Content-Type", "application/json")


### PR DESCRIPTION
## Description

<!-- Describe what this PR does and why. -->

## Linked Issue

Closes #

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor / code quality
- [ ] Documentation update
- [ ] CI / build change

## Testing Done

<!-- Describe how you tested the changes. Include commands run and results observed. -->

**Unit tests (Go):**
```
make test-go
```

**Unit tests (Python):**
```
make test
```

**Linting & type checks:**
```
make lint
make typecheck
```

**Manual testing (if applicable):**
- Describe the scenario tested (e.g. PII type detected, proxy request flow, Chrome extension behavior)
- Include before/after behavior if fixing a bug
- Note any edge cases verified (e.g. nested PII in JSON payloads, restoration accuracy)

## Checklist

- [ ] `make test-go` and `make test` pass locally
- [ ] `make lint` reports no new errors
- [ ] New PII detection changes are covered by unit tests in `tests/`
- [ ] Go proxy changes include test coverage in `src/` or `model/`
- [ ] Documentation updated if behavior or configuration changed
- [ ] No sensitive data or credentials included
