### PR TITLE
chore(model): rewrite Metaflow uv TODO to be self-contained

### DIFF
--- a/model/flows/training_pipeline.py
+++ b/model/flows/training_pipeline.py
@@ -40,16 +40,27 @@ from metaflow import (
 )
 
 ##################################################################
-# Why not use the pyproject.toml dependencies?
-# Because the current Metaflow implementation only uses
-# the pyproject.toml dependencies in the top-level dependencies.
-# A short-term Metaflow limitation should not necessitate a change
-# to this project's pyproject.toml structure. For now, we leverage
-# Metaflow's robust environment building utilities as a stop gap.
-# In the future, we can obviate the need for @pypi if desirable.
-# TODO (Eddie): Update/remove this after feature support for
-#       python flow.py --environment=uv:extra=training run
-# is merged into the Metaflow codebase.
+# Why these package lists exist
+# (they duplicate the optional dependencies in pyproject.toml):
+#
+# When Metaflow runs a flow remotely with --environment=uv, it
+# bundles the whole project (pyproject.toml + uv.lock) and lets
+# uv install everything. There's no way to tell Metaflow "for
+# this specific step, only install the 'training' extra."
+#
+# Because we want different steps to install different subsets
+# of packages (training, quantization, signing), we declare each
+# step's packages here and pass them to @pypi(packages=...).
+#
+# What to do when Metaflow supports per-step extras:
+#   1. Delete every dict in this section.
+#   2. Replace each @pypi(packages=BASE_PACKAGES, ...) with the
+#      new syntax (e.g. @pypi(extra="training")).
+#
+# Verify the limitation in metaflow/plugins/uv/uv_environment.py
+# -- UVEnvironment runs `uv run --no-sync python` without any
+# --extra flag. No upstream issue tracks this feature yet; please
+# file one before starting the cleanup.
 ##################################################################
 BASE_PACKAGES = {
     "torch": ">=2.0.0",


### PR DESCRIPTION
## Description

This PR resolves the vague TODO in `model/flows/training_pipeline.py:50`. As the previous comment ("TODO (Eddie): Update/remove this after feature support for ...") didn't capture what was actually being waited on, forcing anyone touching the file to investigate Metaflow themselves.

Following option 2 of #432 (rewrite the comment to be self-contained), the new comment now explains:
- That the per-step package dicts duplicate `pyproject.toml` extras.
- The specific Metaflow limitation: `UVEnvironment.TYPE = "uv"` accepts no parameters; `executable()` returns `uv run --no-sync python` with no `--extra` flag.
- A reference to `metaflow/plugins/uv/uv_environment.py` so future maintainers can verify the limitation themselves.
- Concrete cleanup steps for when Metaflow ships per-step uv extras.

### Why option 2 (rewrite), not option 1 (remove the workaround)
  
I verified that Metaflow has not shipped per step uv extras support:
- Metaflow's [uv environment plugin]
- No open PR or issue on `Netflix/metaflow` tracks per-step `--environment=uv:extra=...`  
- Latest Metaflow release is `2.19.33` and does not change this.
  
So the dicts and `@pypi(packages=...)` workaround need to stay. The new comment makes that intentional and documented.

## Linked Issue

Closes #432 

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor / code quality
- [x] Documentation update
- [ ] CI / build change

## Testing Done
 
Comment only change no code logic touched, no tests required.

## Checklist

- [ ] `make test-go` and `make test` pass locally
- [x] `make lint` reports no new errors
- [ ] New PII detection changes are covered by unit tests in `tests/`
- [ ] Go proxy changes include test coverage in `src/` or `model/`
- [x] Documentation updated if behavior or configuration changed
- [x] No sensitive data or credentials included
