### PR TITLE
docs: add Rhianna Litchfield to CONTRIBUTORS.md

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -17,6 +17,7 @@ Thank you to everyone who has contributed to Kiji Privacy Proxy!
 - **Yash Dhawan** ([@ykd007](https://github.com/ykd007))
 - **Youssef Jouini** ([@yjouini](https://github.com/yjouini))
 - **Pierre Porée** ([@Pharell](https://github.com/Ph4rell))
+- **Rhianna Litchfield** ([@rhiannalitchfield](https://github.com/rhiannalitchfield))
 
 ---
 


### PR DESCRIPTION
## Purpose
Adding myself to CONTRIBUTORS.md per [CONTRIBUTING.md](https://github.com/dataiku/kiji-proxy/blob/main/CONTRIBUTING.md) guidelines, following the merge of #539.

## What Changed
- Added an entry under Contributors in `CONTRIBUTORS.md`

## Testing
Documentation-only change.