### PR TITLE
fix: bump electron to ^42.4.0 to fix binary extraction on Node 24

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1992,6 +1992,16 @@
         "node": ">=14.17.0"
       }
     },
+    "node_modules/@electron-internal/extract-zip": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@electron-internal/extract-zip/-/extract-zip-1.0.4.tgz",
+      "integrity": "sha512-Zr1Vs7E9tpCNhZHDAbFVXc2gEVCG9RqPDjrno5+bdgB6LRAuvgyMHJut4NCVyYwtAieapMzc3fiQ3CSTi75ARg==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=22.12.0"
+      }
+    },
     "node_modules/@electron/asar": {
       "version": "3.4.1",
       "resolved": "https://registry.npmjs.org/@electron/asar/-/asar-3.4.1.tgz",
@@ -4600,15 +4610,6 @@
         "@types/node": "*"
       }
     },
-    "node_modules/@types/yauzl": {
-      "version": "2.10.3",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "@types/node": "*"
-      }
-    },
     "node_modules/@typescript-eslint/eslint-plugin": {
       "version": "8.60.1",
       "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.60.1.tgz",
@@ -6050,14 +6051,6 @@
         "ieee754": "^1.1.13"
       }
     },
-    "node_modules/buffer-crc32": {
-      "version": "0.2.13",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": "*"
-      }
-    },
     "node_modules/buffer-from": {
       "version": "1.1.2",
       "dev": true,
@@ -7261,15 +7254,15 @@
       }
     },
     "node_modules/electron": {
-      "version": "42.3.0",
-      "resolved": "https://registry.npmjs.org/electron/-/electron-42.3.0.tgz",
-      "integrity": "sha512-9ZiLdRXk+WDxW1OgIUz8J2rIQ5TYU9o629gCOjU48Q3dQiOmym7osWsH5Ubs/Jh4uuFLn6m6SBD2rmRXLAPz9g==",
+      "version": "42.5.0",
+      "resolved": "https://registry.npmjs.org/electron/-/electron-42.5.0.tgz",
+      "integrity": "sha512-cYEKS9XFz+c9fAB4jI0x49yz1FFzB55r3q96wu9YkwwJMv7t9202IE/ltlgy6yitl/J4M7C8JQcmUqdzDvPl/w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
+        "@electron-internal/extract-zip": "^1.0.1",
         "@electron/get": "^5.0.0",
-        "@types/node": "^24.9.0",
-        "extract-zip": "^2.0.1"
+        "@types/node": "^24.9.0"
       },
       "bin": {
         "electron": "cli.js",
@@ -8253,25 +8246,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/extract-zip": {
-      "version": "2.0.1",
-      "dev": true,
-      "license": "BSD-2-Clause",
-      "dependencies": {
-        "debug": "^4.1.1",
-        "get-stream": "^5.1.0",
-        "yauzl": "^2.10.0"
-      },
-      "bin": {
-        "extract-zip": "cli.js"
-      },
-      "engines": {
-        "node": ">= 10.17.0"
-      },
-      "optionalDependencies": {
-        "@types/yauzl": "^2.9.1"
-      }
-    },
     "node_modules/extsprintf": {
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.4.1.tgz",
@@ -8345,14 +8319,6 @@
       },
       "engines": {
         "node": ">=0.8.0"
-      }
-    },
-    "node_modules/fd-slicer": {
-      "version": "1.1.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "pend": "~1.2.0"
       }
     },
     "node_modules/file-entry-cache": {
@@ -11131,11 +11097,6 @@
         "type": "github",
         "url": "https://github.com/sponsors/jet2jet"
       }
-    },
-    "node_modules/pend": {
-      "version": "1.2.0",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/pg-int8": {
       "version": "1.0.1",
@@ -14126,15 +14087,6 @@
         "node": ">=12"
       }
     },
-    "node_modules/yauzl": {
-      "version": "2.10.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "buffer-crc32": "~0.2.3",
-        "fd-slicer": "~1.1.0"
-      }
-    },
     "node_modules/yocto-queue": {
       "version": "0.1.0",
       "dev": true,
@@ -14195,7 +14147,7 @@
         "autoprefixer": "^10.5.0",
         "babel-loader": "^10.1.1",
         "css-loader": "^6.8.0",
-        "electron": "^42.3.0",
+        "electron": "^42.4.0",
         "electron-builder": "^26.8.1",
         "eslint": "^9.39.2",
         "eslint-plugin-react": "^7.33.0",

--- a/src/frontend/package.json
+++ b/src/frontend/package.json
@@ -47,7 +47,7 @@
     "autoprefixer": "^10.5.0",
     "babel-loader": "^10.1.1",
     "css-loader": "^6.8.0",
-    "electron": "^42.3.0",
+    "electron": "^42.4.0",
     "electron-builder": "^26.8.1",
     "eslint": "^9.39.2",
     "eslint-plugin-react": "^7.33.0",


### PR DESCRIPTION
## Summary

`make electron-dev` failed on a fresh install under Node 24: `electron@42.3.0` depended on `extract-zip@2.0.1` → `yauzl@2.10.0`, which silently bails after the first zip entry on Node 24. Electron's `install.js` then produced a partial `dist/` with no `path.txt`, so `require('electron')` threw `ENOENT`.

Electron 42.4.0 replaced the public `extract-zip` dependency with its own dependency-free `@electron-internal/extract-zip`, removing the broken `yauzl` chain at the source. Bumping the spec to `^42.4.0` resolves electron to 42.5.0 and drops `extract-zip@2.0.1` / `yauzl@2.10.0` from the tree entirely — avoiding a `package.json` `overrides` hack.

Verified: binary extracts fully (`dist/version` = 42.5.0, `path.txt` present), `require('electron')` resolves, and the frontend `npm run build` (html-webpack-plugin) compiles cleanly.

Closes #555