### PR TITLE
fix(ci): stop executing fork code in check-scope job

### DIFF
--- a/.github/workflows/semantic-pr.yml
+++ b/.github/workflows/semantic-pr.yml
@@ -70,11 +70,19 @@ jobs:
     name: Check PR scope
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout PR
+      # No `ref:` here: this job runs under pull_request_target with the base
+      # repo's GITHUB_TOKEN, so it must check out the trusted base branch
+      # (the default ref) rather than fork-controlled code. The PR head is
+      # fetched as data only below, never checked out or executed.
+      - name: Checkout base (trusted)
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
-          ref: ${{ github.event.pull_request.head.sha }}
           fetch-depth: 0
+
+      - name: Fetch PR head
+        env:
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: git fetch origin "$HEAD_SHA"
 
       - name: Classify changed files
         id: classify

--- a/.github/workflows/semantic-pr.yml
+++ b/.github/workflows/semantic-pr.yml
@@ -78,11 +78,27 @@ jobs:
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           fetch-depth: 0
+          persist-credentials: false
 
-      - name: Fetch PR head
+      - name: Fetch PR head (data only)
         env:
+          PR_NUMBER: ${{ github.event.pull_request.number }}
           HEAD_SHA: ${{ github.event.pull_request.head.sha }}
-        run: git fetch origin "$HEAD_SHA"
+        run: |
+          set -euo pipefail
+          # Fetch the advertised PR head ref as data only. This does not check
+          # out or execute fork-controlled code, preserving the checkout@v7
+          # pull_request_target pwn-request protection.
+          git fetch --no-tags --no-recurse-submodules origin \
+            "refs/pull/${PR_NUMBER}/head"
+          fetched_sha="$(git rev-parse FETCH_HEAD)"
+          # Ensure the ref still points at the SHA from the event payload, so we
+          # classify exactly the reviewed head and never whatever a fork may
+          # have pushed after the workflow was triggered.
+          if [ "$fetched_sha" != "$HEAD_SHA" ]; then
+            echo "::error::PR head ref ($fetched_sha) does not match event head.sha ($HEAD_SHA)."
+            exit 1
+          fi
 
       - name: Classify changed files
         id: classify


### PR DESCRIPTION
## Purpose
Resolves #554. The `check-scope` job runs under `pull_request_target` carrying the base repo's `GITHUB_TOKEN` (with `pull-requests: write`), but checked out and executed fork-controlled code via `ref: ${{ github.event.pull_request.head.sha }}`. A malicious fork PR could replace `.github/scripts/classify-pr-files.sh` to exfiltrate the token or abuse write permissions (classic "pwn request").

This was also surfacing as a functional break: `actions/checkout@v7` (#551) now refuses to check out fork PR code by default under `pull_request_target`.

## What Changed
- `check-scope` now checks out the **trusted base ref** (omits `ref:`), so the trusted copy of `classify-pr-files.sh` runs.
- Added a `git fetch origin "$HEAD_SHA"` step to pull the PR head's objects as data only — never checked out, never executed.
- `classify-pr-files.sh` already only computes `git diff BASE_SHA...HEAD_SHA --name-only`, so it needs the head SHA's objects, not the fork's working tree or any executable code from it.

This follows the fix explicitly recommended in the issue (option 1) and avoids the discouraged `allow-unsafe-pr-checkout: true` workaround.

## Testing
CI-only change; verified the new `git fetch` + diff flow reproduces the same file list the previous checkout-based diff produced, without checking out or executing fork content.