### PR TITLE
fix: dashboard data correctness and per-poll efficiency

### DIFF
--- a/src/backend/pii/database.go
+++ b/src/backend/pii/database.go
@@ -367,8 +367,13 @@ func (s *SQLitePIIMappingDB) GetMappings(ctx context.Context, limit int, offset 
 		}
 
 		// Parse created_at into time.Time so it serializes as RFC3339 for the
-		// frontend (matching how GetLogs returns timestamps).
-		parsedCreated, _ := time.Parse("2006-01-02 15:04:05", createdAt)
+		// frontend (matching how GetLogs returns timestamps). On failure log it
+		// (rather than silently swallowing) and keep the row with the zero time so
+		// the paginated mappings view doesn't drop entries.
+		parsedCreated, err := time.Parse("2006-01-02 15:04:05", createdAt)
+		if err != nil {
+			log.Printf("[SQLiteDB] ⚠️  Mapping row %d has unparseable created_at %q: %v", id, createdAt, err)
+		}
 
 		mappings = append(mappings, map[string]interface{}{
 			"id":                     id,
@@ -512,8 +517,13 @@ func (s *SQLitePIIMappingDB) GetLogs(ctx context.Context, limit int, offset int)
 
 		detectedPIIStr := formatDetectedPII(detectedPII)
 
-		// Parse timestamp
-		parsedTime, _ := time.Parse("2006-01-02 15:04:05", timestamp)
+		// Parse timestamp. On failure log it (rather than silently swallowing) and
+		// fall through with the zero time so the row still shows in the paginated
+		// /logs view instead of being dropped.
+		parsedTime, err := time.Parse("2006-01-02 15:04:05", timestamp)
+		if err != nil {
+			log.Printf("[SQLiteDB] ⚠️  Log row %d has unparseable timestamp %q: %v", id, timestamp, err)
+		}
 
 		logEntry := map[string]interface{}{
 			"id":           id,
@@ -645,7 +655,15 @@ func scanMetricsSeedRows(rows *sql.Rows) ([]MetricsSeedRow, error) {
 			confs = append(confs, e.Confidence)
 		}
 
-		parsedTime, _ := time.Parse("2006-01-02 15:04:05", timestamp)
+		parsedTime, err := time.Parse("2006-01-02 15:04:05", timestamp)
+		if err != nil {
+			// Skip a row with an unparseable timestamp rather than letting it
+			// default to the zero time (year 0001). A zero-time row would otherwise
+			// anchor the dashboard's "all"-range window at year 0001 and blow up its
+			// dense per-day bucket loop.
+			log.Printf("[SQLiteDB] ⚠️  Skipping metrics seed row with unparseable timestamp %q: %v", timestamp, err)
+			continue
+		}
 
 		row := MetricsSeedRow{Timestamp: parsedTime, Types: types, Confidences: confs}
 		if model.Valid {

--- a/src/backend/pii/model_manager.go
+++ b/src/backend/pii/model_manager.go
@@ -2,6 +2,7 @@ package pii
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"log"
@@ -31,6 +32,12 @@ type ModelManager struct {
 	isHealthy                 bool
 	lastError                 error
 	entityConfidenceThreshold float64
+	// modelSignature and modelHash identify the currently-loaded model. They are
+	// parsed from model_manifest.json at load time (see ReloadModel), keyed to the
+	// directory actually loaded, so callers like the dashboard report model
+	// identity without re-reading the file and the values track hot reloads.
+	modelSignature string
+	modelHash      string
 }
 
 // ModelConfig holds paths to required model files
@@ -148,12 +155,19 @@ func (mm *ModelManager) ReloadModel(newDirectory string) error {
 		return fmt.Errorf("model validation failed: %w", err)
 	}
 
+	// Parse the model's identity (signature + short hash) from its manifest now,
+	// outside the swap lock, sourced from the directory actually being loaded so a
+	// reload to a different directory is reflected in GetInfo/GetModelIdentity.
+	signature, hash := readModelIdentity(newDirectory)
+
 	// Step 4: Apply stored confidence threshold and swap detectors atomically
 	mm.mu.Lock()
 	newDetector.SetEntityConfidenceThreshold(mm.entityConfidenceThreshold)
 	oldDetector := mm.currentDetector
 	mm.currentDetector = newDetector
 	mm.modelDirectory = newDirectory
+	mm.modelSignature = signature
+	mm.modelHash = hash
 	mm.isHealthy = true
 	mm.lastError = nil
 	mm.mu.Unlock()
@@ -228,6 +242,8 @@ func (mm *ModelManager) GetInfo() map[string]interface{} {
 
 	info := map[string]interface{}{
 		"directory":    mm.modelDirectory,
+		"signature":    mm.modelSignature,
+		"hash":         mm.modelHash,
 		"healthy":      mm.isHealthy,
 		"confidence":   mm.entityConfidenceThreshold,
 		"onnx_enabled": mm.onnxEnabled,
@@ -241,6 +257,42 @@ func (mm *ModelManager) GetInfo() map[string]interface{} {
 	}
 
 	return info
+}
+
+// GetModelIdentity returns the signature and short hash of the currently-loaded
+// model, parsed from its manifest at load time (and refreshed on every reload).
+func (mm *ModelManager) GetModelIdentity() (signature, hash string) {
+	mm.mu.RLock()
+	defer mm.mu.RUnlock()
+	return mm.modelSignature, mm.modelHash
+}
+
+// readModelIdentity parses the model signature and short hash from
+// model_manifest.json in dir. It returns the default signature ("onnx-pii") and
+// an empty hash when the manifest is missing or unparseable — the manifest is
+// best-effort metadata and not required for the model to run.
+func readModelIdentity(dir string) (signature, hash string) {
+	signature = "onnx-pii"
+	data, err := os.ReadFile(filepath.Join(dir, "model_manifest.json")) // #nosec G304 — dir is validated before load
+	if err != nil {
+		return signature, ""
+	}
+	var manifest map[string]interface{}
+	if err := json.Unmarshal(data, &manifest); err != nil {
+		return signature, ""
+	}
+	for _, k := range []string{"model", "name", "version"} {
+		if v, ok := manifest[k].(string); ok && v != "" {
+			signature = v
+			break
+		}
+	}
+	if hashes, ok := manifest["hashes"].(map[string]interface{}); ok {
+		if sha, ok := hashes["sha256"].(string); ok && len(sha) >= 7 {
+			hash = sha[:7]
+		}
+	}
+	return signature, hash
 }
 
 // validateDirectory checks that the directory exists and contains all required files

--- a/src/backend/pii/model_manager_test.go
+++ b/src/backend/pii/model_manager_test.go
@@ -1,0 +1,121 @@
+package pii
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// writeManifest writes model_manifest.json with the given contents into a fresh
+// temp dir and returns the dir path.
+func writeManifest(t *testing.T, contents string) string {
+	t.Helper()
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "model_manifest.json"), []byte(contents), 0o600); err != nil {
+		t.Fatalf("write manifest: %v", err)
+	}
+	return dir
+}
+
+func TestReadModelIdentity(t *testing.T) {
+	tests := []struct {
+		name     string
+		manifest string // when empty, no manifest file is written
+		wantSig  string
+		wantHash string
+	}{
+		{
+			name:     "missing manifest falls back to default signature",
+			manifest: "",
+			wantSig:  "onnx-pii",
+			wantHash: "",
+		},
+		{
+			name:     "malformed json falls back to default signature",
+			manifest: "{ not json",
+			wantSig:  "onnx-pii",
+			wantHash: "",
+		},
+		{
+			name:     "model field wins as signature",
+			manifest: `{"model":"distilbert-pii","name":"ignored","version":"9"}`,
+			wantSig:  "distilbert-pii",
+			wantHash: "",
+		},
+		{
+			name:     "name used when model absent",
+			manifest: `{"name":"pii-ner","version":"9"}`,
+			wantSig:  "pii-ner",
+			wantHash: "",
+		},
+		{
+			name:     "version used when model and name absent",
+			manifest: `{"version":"2026.06"}`,
+			wantSig:  "2026.06",
+			wantHash: "",
+		},
+		{
+			name:     "sha256 is truncated to 7 chars",
+			manifest: `{"model":"m","hashes":{"sha256":"2b657df1f9a2deadbeef"}}`,
+			wantSig:  "m",
+			wantHash: "2b657df",
+		},
+		{
+			name:     "no recognized signature key but a hash (mirrors the quantized model)",
+			manifest: `{"hashes":{"sha256":"2b657df1f9a2"}}`,
+			wantSig:  "onnx-pii",
+			wantHash: "2b657df",
+		},
+		{
+			name:     "short sha256 is ignored",
+			manifest: `{"model":"m","hashes":{"sha256":"abc"}}`,
+			wantSig:  "m",
+			wantHash: "",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			var dir string
+			if tc.manifest == "" {
+				dir = t.TempDir() // exists, but contains no manifest
+			} else {
+				dir = writeManifest(t, tc.manifest)
+			}
+			sig, hash := readModelIdentity(dir)
+			if sig != tc.wantSig {
+				t.Errorf("signature = %q, want %q", sig, tc.wantSig)
+			}
+			if hash != tc.wantHash {
+				t.Errorf("hash = %q, want %q", hash, tc.wantHash)
+			}
+		})
+	}
+}
+
+// TestReadModelIdentity_TracksDirectory is the regression guard for the bug fix:
+// identity is derived from the directory passed in, so two different model
+// directories yield their own signature/hash rather than a single cached value.
+func TestReadModelIdentity_TracksDirectory(t *testing.T) {
+	dirA := writeManifest(t, `{"model":"model-a","hashes":{"sha256":"aaaaaaa0000"}}`)
+	dirB := writeManifest(t, `{"model":"model-b","hashes":{"sha256":"bbbbbbb1111"}}`)
+
+	sigA, hashA := readModelIdentity(dirA)
+	sigB, hashB := readModelIdentity(dirB)
+
+	if sigA != "model-a" || hashA != "aaaaaaa" {
+		t.Errorf("dir A identity = (%q,%q), want (model-a, aaaaaaa)", sigA, hashA)
+	}
+	if sigB != "model-b" || hashB != "bbbbbbb" {
+		t.Errorf("dir B identity = (%q,%q), want (model-b, bbbbbbb)", sigB, hashB)
+	}
+}
+
+// TestGetModelIdentity confirms the accessor returns the fields set at load time.
+func TestGetModelIdentity(t *testing.T) {
+	mm := &ModelManager{modelSignature: "sig-x", modelHash: "hash-y"}
+	sig, hash := mm.GetModelIdentity()
+	if sig != "sig-x" || hash != "hash-y" {
+		t.Errorf("GetModelIdentity() = (%q,%q), want (sig-x, hash-y)", sig, hash)
+	}
+}

--- a/src/backend/proxy/handler.go
+++ b/src/backend/proxy/handler.go
@@ -64,6 +64,16 @@ func (h *Handler) IsModelHealthy() bool {
 	return h.modelManager.IsHealthy()
 }
 
+// ModelIdentity returns the signature and short hash of the currently-loaded PII
+// model. It returns the default signature with an empty hash when no model
+// manager is configured.
+func (h *Handler) ModelIdentity() (signature, hash string) {
+	if h.modelManager == nil {
+		return "onnx-pii", ""
+	}
+	return h.modelManager.GetModelIdentity()
+}
+
 // GetModelError returns the last model error (if any)
 func (h *Handler) GetModelError() error {
 	if h.modelManager == nil {

--- a/src/backend/server/dashboard.go
+++ b/src/backend/server/dashboard.go
@@ -6,11 +6,10 @@ import (
 	"fmt"
 	"log"
 	"net/http"
-	"os"
-	"path/filepath"
 	"sort"
 	"strconv"
 	"strings"
+	"sync"
 	"time"
 
 	piiServices "github.com/dataiku/kiji-proxy/src/backend/pii"
@@ -40,6 +39,13 @@ const (
 	range30d = "30d"
 	range90d = "90d"
 	rangeAll = "all"
+
+	// maxDenseBuckets caps how many zero-filled buckets buildDenseTimeseries will
+	// emit. It guards the "all" range against a corrupt/zero log timestamp (e.g.
+	// year 0001) turning the per-bucket loop into hundreds of thousands of
+	// iterations. ~5.5 years of daily buckets is far more history than the proxy
+	// realistically retains, so legitimate ranges are never clamped.
+	maxDenseBuckets = 2000
 )
 
 // --- response shapes (json tags mirror docs/dashboard-api.md) ---
@@ -242,11 +248,15 @@ func (s *Server) buildDashboard(rangeStr string, dur time.Duration) dashboardRes
 		DeltaWindow: snap.DeltaWindow, Spark: spark,
 	}
 	resp.KPIs.RequestsProxied = kpiRequests{Total: snap.Requests, Today: snap.RequestsToday}
-	// rate := 1.0
-	// if denom := snap.PIIMasked + snap.Leaked; denom > 0 {
-	// 	rate = round2(float64(snap.PIIMasked) / float64(denom))
-	// }
-	// resp.KPIs.PIILeaked = kpiLeaked{Total: snap.Leaked, MaskedRate: rate}
+	// masked_rate = masked / (masked + leaked). With nothing leaked the rate is
+	// 1.0 ("everything detected was masked"), which keeps this branch consistent
+	// with the day-one / metrics-unavailable branch above (Total 0, MaskedRate
+	// 1.0) instead of reporting a misleading 0.
+	rate := 1.0
+	if denom := snap.PIIMasked + snap.Leaked; denom > 0 {
+		rate = round2(float64(snap.PIIMasked) / float64(denom))
+	}
+	resp.KPIs.PIILeaked = kpiLeaked{Total: snap.Leaked, MaskedRate: rate}
 	resp.KPIs.LatencyMS = kpiLatency{AvgAdded: snap.LatencyAvg, P95Added: snap.LatencyP95}
 	resp.KPIs.DetectionConfidence = kpiConfidence{Avg: round2(snap.ConfidenceAvg)}
 
@@ -317,6 +327,14 @@ func (s *Server) buildDashboard(rangeStr string, dur time.Duration) dashboardRes
 // all activity falls on a single day. Returns ok=false when the store can't
 // supply rows, so the caller falls back to the in-memory collector.
 func (s *Server) dashboardFromSQLite(rangeStr string, dur time.Duration, now time.Time) (timeseriesBlock, compositionBlock, bool) {
+	// Serve a recent computation from the per-range cache: DashboardWindowRows
+	// full-scans the logs table, and the UI polls every ~10s, so a few seconds of
+	// caching collapses bursty/duplicate polls onto a single scan at the cost of a
+	// little staleness on an activity dashboard.
+	if ts, comp, ok := dashboardWindowCacheGet(rangeStr, now); ok {
+		return ts, comp, true
+	}
+
 	bucketID, start, querySince := dashboardWindow(rangeStr, dur, now)
 
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
@@ -348,7 +366,49 @@ func (s *Server) dashboardFromSQLite(rangeStr string, dur time.Duration, now tim
 		Bucket: bucketID,
 		Points: buildDenseTimeseries(rows, bucketID, start, now),
 	}
-	return ts, buildComposition(rows), true
+	comp := buildComposition(rows)
+	dashboardWindowCachePut(rangeStr, now, ts, comp)
+	return ts, comp, true
+}
+
+// dashboardWindowCacheTTL bounds how long a computed SQLite-backed timeseries +
+// composition is reused across polls. Kept short so the dashboard stays close to
+// live while still absorbing the duplicate/bursty polls the UI generates.
+const dashboardWindowCacheTTL = 5 * time.Second
+
+type dashboardWindowCacheEntry struct {
+	expires time.Time
+	ts      timeseriesBlock
+	comp    compositionBlock
+}
+
+// Process-global cache keyed by range id. The proxy runs a single Server per
+// process, so a package-level cache is sufficient and avoids widening the Server
+// struct. Only successful computations are cached (failures fall back to the
+// in-memory collector and are retried next poll).
+var (
+	dashboardWindowCacheMu sync.Mutex
+	dashboardWindowCache   = map[string]dashboardWindowCacheEntry{}
+)
+
+func dashboardWindowCacheGet(rangeStr string, now time.Time) (timeseriesBlock, compositionBlock, bool) {
+	dashboardWindowCacheMu.Lock()
+	defer dashboardWindowCacheMu.Unlock()
+	e, ok := dashboardWindowCache[rangeStr]
+	if !ok || now.After(e.expires) {
+		return timeseriesBlock{}, compositionBlock{}, false
+	}
+	return e.ts, e.comp, true
+}
+
+func dashboardWindowCachePut(rangeStr string, now time.Time, ts timeseriesBlock, comp compositionBlock) {
+	dashboardWindowCacheMu.Lock()
+	defer dashboardWindowCacheMu.Unlock()
+	dashboardWindowCache[rangeStr] = dashboardWindowCacheEntry{
+		expires: now.Add(dashboardWindowCacheTTL),
+		ts:      ts,
+		comp:    comp,
+	}
 }
 
 // dashboardWindow returns the bucket granularity, the (UTC) start of the first
@@ -376,11 +436,25 @@ func dashboardWindow(rangeStr string, dur time.Duration, now time.Time) (bucketI
 func buildDenseTimeseries(rows []piiServices.MetricsSeedRow, bucketID string, start, now time.Time) []tsPoint {
 	floor := floorDay
 	step := func(t time.Time) time.Time { return t.AddDate(0, 0, 1) }
+	back := func(t time.Time) time.Time { return t.AddDate(0, 0, -1) }
 	label := func(t time.Time) string { return t.Format("2006-01-02") }
 	if bucketID == bucketHour {
 		floor = floorHour
 		step = func(t time.Time) time.Time { return t.Add(time.Hour) }
+		back = func(t time.Time) time.Time { return t.Add(-time.Hour) }
 		label = func(t time.Time) string { return t.Format("2006-01-02T15:00") }
+	}
+
+	// Defensive clamp: a corrupt/zero start (e.g. year 0001 from an unparseable
+	// log timestamp) would otherwise loop one bucket/step for millennia and
+	// exhaust memory. Cap the window to the most recent maxDenseBuckets buckets
+	// ending at now, dropping the unreachable older tail.
+	earliest := floor(now)
+	for i := 0; i < maxDenseBuckets-1; i++ {
+		earliest = back(earliest)
+	}
+	if start.Before(earliest) {
+		start = earliest
 	}
 
 	counts := make(map[string]int64)
@@ -496,31 +570,13 @@ func parseDashboardRange(s string) (string, time.Duration, error) {
 	}
 }
 
-// dashboardModelInfo returns a best-effort model signature, short hash, and health.
+// dashboardModelInfo returns a best-effort model signature, short hash, and
+// health. All three come from the model manager (the source of truth for what's
+// actually loaded), so the signature/hash track hot reloads and the dashboard
+// never reads the manifest from disk on the poll path.
 func (s *Server) dashboardModelInfo() (signature, hash string, healthy bool) {
 	healthy = s.handler.IsModelHealthy()
-	signature = "onnx-pii"
-
-	manifestPath := filepath.Join(s.config.ResolveModelDirectory(), "model_manifest.json")
-	data, err := os.ReadFile(manifestPath) // #nosec G304 — path derived from validated config
-	if err != nil {
-		return signature, "", healthy
-	}
-	var manifest map[string]interface{}
-	if err := json.Unmarshal(data, &manifest); err != nil {
-		return signature, "", healthy
-	}
-	for _, k := range []string{"model", "name", "version"} {
-		if v, ok := manifest[k].(string); ok && v != "" {
-			signature = v
-			break
-		}
-	}
-	if hashes, ok := manifest["hashes"].(map[string]interface{}); ok {
-		if sha, ok := hashes["sha256"].(string); ok && len(sha) >= 7 {
-			hash = sha[:7]
-		}
-	}
+	signature, hash = s.handler.ModelIdentity()
 	return signature, hash, healthy
 }
 


### PR DESCRIPTION
## Summary

Fixes four issues in the new dashboard backend (all in `server/dashboard.go` + `pii/database.go`):

- **`pii_leaked.masked_rate` always 0 on the live path.** `handler.Metrics()` is never nil, so `buildDashboard` always took the `mc != nil` branch where the rate assignment was commented out — returning `masked_rate: 0` even at 100% masking (confirmed at runtime: 8 masked / 0 leaked → 0). Restored `rate = masked / (masked + leaked)`, defaulting to `1.0` when nothing leaked, consistent with the day-one branch.
- **`?range=all` could OOM.** A zero/garbage log timestamp made `start` year 0001, and `buildDenseTimeseries` looped one bucket/day to now (~739k iterations). Added a `maxDenseBuckets` clamp; legitimate ranges are never affected.
- **Swallowed `time.Parse` errors** (`scanMetricsSeedRows`, `GetLogs`, `GetMappings`) silently produced zero times (root cause of the above). The metrics path now skips unparseable rows; the paginated views log and keep the row.
- **Per-poll waste.** `model_manifest.json` was re-read+parsed and the logs table full-scanned on every ~10s poll. Added a cached manifest (per model dir) and a short-TTL per-range cache for the SQLite aggregate.