### PR TITLE
fix: route /api/dashboard on transparent proxy and restore system proxy on shutdown

### DIFF
--- a/src/backend/server/server.go
+++ b/src/backend/server/server.go
@@ -10,9 +10,11 @@ import (
 	"net"
 	"net/http"
 	"os"
+	"os/signal"
 	"path/filepath"
 	"strings"
 	"sync"
+	"syscall"
 	"time"
 
 	"github.com/dataiku/kiji-proxy/src/backend/config"
@@ -415,6 +417,8 @@ func (s *Server) startTransparentProxy() {
 			s.mappingsHandler(w, r)
 		case "/api/stats", "/stats":
 			s.statsHandler(w, r)
+		case "/api/dashboard":
+			s.dashboardHandler(w, r)
 		case "/api/model/security":
 			s.handleModelSecurity(w, r)
 		case "/api/proxy/ca-cert":
@@ -641,9 +645,16 @@ func (s *Server) statsHandler(w http.ResponseWriter, r *http.Request) {
 }
 
 func (s *Server) handleModelSecurity(w http.ResponseWriter, r *http.Request) {
-	// Read model manifest from whichever variant is currently active.
-	manifestPath := filepath.Join(s.config.ResolveModelDirectory(), "model_manifest.json")
-	data, err := os.ReadFile(manifestPath) // #nosec G304 — path derived from validated config
+	// Read the manifest from the directory the model manager actually loaded (it
+	// tracks hot reloads), falling back to the configured directory if the manager
+	// hasn't reported one. Reading the static config path here would report the
+	// original model's manifest after a reload pointed at a different directory.
+	modelDir := s.config.ResolveModelDirectory()
+	if dir, ok := s.handler.GetModelInfo()["directory"].(string); ok && dir != "" {
+		modelDir = dir
+	}
+	manifestPath := filepath.Join(modelDir, "model_manifest.json")
+	data, err := os.ReadFile(manifestPath) // #nosec G304 — path derived from validated config/model manager
 
 	if err != nil {
 		http.Error(w, "Model manifest not found", http.StatusNotFound)
@@ -656,8 +667,15 @@ func (s *Server) handleModelSecurity(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// Extract hashes.sha256 defensively: a manifest without a "hashes" object (or
+	// without a string sha256) must not panic the handler.
+	var sha256 interface{}
+	if hashes, ok := manifest["hashes"].(map[string]interface{}); ok {
+		sha256 = hashes["sha256"]
+	}
+
 	response := map[string]interface{}{
-		"hash":     manifest["hashes"].(map[string]interface{})["sha256"],
+		"hash":     sha256,
 		"manifest": manifest,
 	}
 
@@ -1092,8 +1110,26 @@ func (s *Server) handleModelInfo(w http.ResponseWriter, r *http.Request) {
 	}
 }
 
-// StartWithErrorHandling starts the server with proper error handling
+// StartWithErrorHandling starts the server with proper error handling.
+//
+// Start blocks in ListenAndServe, so a process-level SIGTERM/SIGINT would
+// otherwise kill the proxy without ever running Close(). That matters on macOS:
+// Start() enables the system auto-proxy (PAC at localhost:9090) and only
+// Close() tears it back down, so an abrupt exit leaves the machine pointed at a
+// dead PAC server. Install a signal handler that runs the same cleanup as Close
+// before exiting.
 func (s *Server) StartWithErrorHandling() {
+	sigCh := make(chan os.Signal, 1)
+	signal.Notify(sigCh, syscall.SIGTERM, syscall.SIGINT)
+	go func() {
+		sig := <-sigCh
+		log.Printf("Received signal %v, shutting down and restoring system proxy...", sig)
+		if err := s.Close(); err != nil {
+			log.Printf("Warning: Error during shutdown cleanup: %v", err)
+		}
+		os.Exit(0)
+	}()
+
 	if err := s.Start(); err != nil {
 		log.Fatalf("Failed to start server: %v", err)
 	}
@@ -1133,6 +1169,7 @@ func isTransparentAdminProtectedPath(p string) bool {
 	case "/api/logs", "/logs",
 		"/api/mappings", "/mappings",
 		"/api/stats", "/stats",
+		"/api/dashboard",
 		"/api/model/security",
 		"/api/proxy/ca-cert":
 		return true

--- a/src/backend/server/transparent_router_auth_test.go
+++ b/src/backend/server/transparent_router_auth_test.go
@@ -1,0 +1,100 @@
+package server
+
+import (
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"strconv"
+	"testing"
+)
+
+// TestTransparentRouterAdminPathsAreProtected guards against a route being added
+// to startTransparentProxy's path switch without also being registered as a
+// Basic-Auth-protected path. The transparent listener is default-ALLOW (only
+// paths in isTransparentAdminProtectedPath are challenged), so a new admin/data
+// case that is not also listed there would silently ship unauthenticated.
+//
+// The test reads the explicit case values out of the switch via the AST (so a
+// newly added route is picked up automatically) and asserts the invariant: any
+// switch case that is not a public path (health/version probes, /api/pii/*, or
+// proxy traffic per isBasicAuthPublicPath) must be reported as protected by
+// isTransparentAdminProtectedPath.
+func TestTransparentRouterAdminPathsAreProtected(t *testing.T) {
+	cases := transparentRouterSwitchPaths(t)
+	if len(cases) == 0 {
+		t.Fatal("found no case paths in startTransparentProxy's router switch; did the function move?")
+	}
+
+	for _, p := range cases {
+		if isBasicAuthPublicPath(p) {
+			continue // intentionally open (health/version/pii)
+		}
+		if !isTransparentAdminProtectedPath(p) {
+			t.Errorf("transparent router serves %q but it is not in isTransparentAdminProtectedPath; "+
+				"it would be reachable without Basic Auth. Add it to isTransparentAdminProtectedPath.", p)
+		}
+	}
+}
+
+// transparentRouterSwitchPaths parses server.go and returns the string literals
+// used as case values in the `switch r.URL.Path` inside startTransparentProxy.
+func transparentRouterSwitchPaths(t *testing.T) []string {
+	t.Helper()
+
+	fset := token.NewFileSet()
+	file, err := parser.ParseFile(fset, "server.go", nil, 0)
+	if err != nil {
+		t.Fatalf("parse server.go: %v", err)
+	}
+
+	var fn *ast.FuncDecl
+	for _, decl := range file.Decls {
+		if d, ok := decl.(*ast.FuncDecl); ok && d.Name.Name == "startTransparentProxy" {
+			fn = d
+			break
+		}
+	}
+	if fn == nil {
+		t.Fatal("could not find startTransparentProxy in server.go")
+	}
+
+	var paths []string
+	ast.Inspect(fn, func(n ast.Node) bool {
+		sw, ok := n.(*ast.SwitchStmt)
+		if !ok || !isReqURLPathSelector(sw.Tag) {
+			return true
+		}
+		for _, stmt := range sw.Body.List {
+			clause, ok := stmt.(*ast.CaseClause)
+			if !ok {
+				continue
+			}
+			for _, expr := range clause.List {
+				lit, ok := expr.(*ast.BasicLit)
+				if !ok || lit.Kind != token.STRING {
+					continue
+				}
+				if s, err := strconv.Unquote(lit.Value); err == nil {
+					paths = append(paths, s)
+				}
+			}
+		}
+		return true
+	})
+	return paths
+}
+
+// isReqURLPathSelector reports whether expr is the `r.URL.Path` selector used as
+// the switch tag in the transparent router.
+func isReqURLPathSelector(expr ast.Expr) bool {
+	path, ok := expr.(*ast.SelectorExpr)
+	if !ok || path.Sel.Name != "Path" {
+		return false
+	}
+	url, ok := path.X.(*ast.SelectorExpr)
+	if !ok || url.Sel.Name != "URL" {
+		return false
+	}
+	r, ok := url.X.(*ast.Ident)
+	return ok && r.Name == "r"
+}


### PR DESCRIPTION
## Summary

- **Transparent proxy didn't route `/api/dashboard`.** It was registered on the main mux but had no case in the transparent router switch, so `:8081/api/dashboard` fell through to the proxy default and returned `HTTP 400 "Error retrieving provider from host"` (confirmed at runtime). Added the case and added `/api/dashboard` to `isTransparentAdminProtectedPath` so it's Basic-Auth-gated like the other admin endpoints.
- **Auth-invariant safeguard.** Added `TestTransparentRouterAdminPathsAreProtected`, which parses the router switch via go/ast and asserts every non-public admin case is also in `isTransparentAdminProtectedPath` — so a future route can't silently ship unauthenticated on the transparent listener.
- **System proxy not restored on shutdown.** `Start()` blocks in `ListenAndServe`, so SIGTERM/SIGINT killed the process without running `Close()` — leaving the macOS system auto-proxy pointed at a dead PAC server. Added a signal handler that runs the existing `Close()` cleanup (which disables the system proxy) before exiting.