### PR TITLE
fix: send admins to the Dashboard when onboarding chooses the admin role

### DIFF
--- a/src/frontend/src/components/AppShell.tsx
+++ b/src/frontend/src/components/AppShell.tsx
@@ -8,6 +8,7 @@ import ActivityView from "./activity/ActivityView";
 import MappingsView from "./mappings/MappingsView";
 import AboutView from "./about/AboutView";
 import PrivacyProxyUI from "./privacy-proxy-ui";
+import { ADMIN_ROLE_CHOSEN_EVENT } from "./onboarding/WelcomeModal";
 
 /**
  * Top-level shell for the proxy app.
@@ -56,6 +57,18 @@ export default function AppShell() {
     resolveInitialView();
     return () => {
       cancelled = true;
+    };
+  }, []);
+
+  // The initial view is resolved once on mount, but onboarding can choose the
+  // admin role afterwards (WelcomeModal lives under the Playground). When that
+  // happens, send the new admin straight to the Dashboard for this session
+  // instead of waiting for a restart to re-read the flag.
+  useEffect(() => {
+    const handleAdminChosen = () => setView("dashboard");
+    window.addEventListener(ADMIN_ROLE_CHOSEN_EVENT, handleAdminChosen);
+    return () => {
+      window.removeEventListener(ADMIN_ROLE_CHOSEN_EVENT, handleAdminChosen);
     };
   }, []);
   // Bumped after a successful provider save so the Playground re-reads its

--- a/src/frontend/src/components/onboarding/WelcomeModal.tsx
+++ b/src/frontend/src/components/onboarding/WelcomeModal.tsx
@@ -17,6 +17,12 @@ interface WelcomeModalProps {
   onClose: () => void;
 }
 
+// Broadcast on the window when onboarding picks the admin role. AppShell renders
+// this modal indirectly (via the Playground) and resolves the launch view once on
+// mount, so it can't observe `setAdmin` through props — it listens for this event
+// instead and navigates admins to the Dashboard without waiting for a restart.
+export const ADMIN_ROLE_CHOSEN_EVENT = "kiji:admin-role-chosen";
+
 const promises = [
   {
     icon: Lock,
@@ -58,6 +64,8 @@ export default function WelcomeModal({ isOpen, onClose }: WelcomeModalProps) {
     if (isElectron && window.electronAPI) {
       try {
         await window.electronAPI.setAdmin(true);
+        // Let AppShell re-resolve the launch view now that the role is known.
+        window.dispatchEvent(new Event(ADMIN_ROLE_CHOSEN_EVENT));
       } catch (error) {
         console.error("Failed to save admin preference:", error);
       }


### PR DESCRIPTION
## Summary

On first launch, `AppShell` resolved the launch view exactly once on mount via `getAdmin()`. The onboarding `WelcomeModal` sets the admin flag afterwards, with nothing re-resolving the view — so a first-run admin was stranded on the Playground until an app restart, contradicting the documented "admins land on the Dashboard" intent.

`WelcomeModal` is rendered under the Playground (`privacy-proxy-ui.tsx`), not directly by `AppShell`, so it dispatches a `window` event (`kiji:admin-role-chosen`) after a successful `setAdmin(true)`; `AppShell` listens and navigates to the Dashboard. The web (basic-auth) path and the "I'm a user"/dismiss paths are unaffected.