### PR TITLE
chore: changeset for v1.4.0 release

### DIFF
--- a/.changeset/release-1-4-0.md
+++ b/.changeset/release-1-4-0.md
@@ -1,0 +1,7 @@
+---
+"kiji-privacy-proxy": minor
+---
+
+- Reworked the desktop UI and made the UI available in the Linux standalone version.
+- Bumped Electron to ^42.4.0 to fix binary extraction on Node 24.
+- `make electron-dev` now verifies and announces dev-server reuse.


### PR DESCRIPTION
## Summary

Adds the changeset that starts the v1.4.0 release (minor bump from 1.3.1).

Bundled changes since 1.3.1:
- Reworked the desktop UI and made the UI available in the Linux standalone version (#547).
- Bumped Electron to ^42.4.0 to fix binary extraction on Node 24 (#556).
- `make electron-dev` now verifies and announces dev-server reuse (#558).

On merge, the Changesets bot will open the "version packages" PR bumping to 1.4.0.