### PR TITLE
fix: build fails on Linux/Intel macOS due to missing native optional deps

### DIFF
--- a/.changeset/fix-linux-build-native-deps.md
+++ b/.changeset/fix-linux-build-native-deps.md
@@ -1,0 +1,5 @@
+---
+"kiji-privacy-proxy": patch
+---
+
+- Declared the platform-native optional dependencies so the frontend build resolves on Linux and Intel macOS, fixing builds that failed due to missing native optional deps.

--- a/package-lock.json
+++ b/package-lock.json
@@ -4222,11 +4222,62 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
         "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-darwin-x64": {
+      "version": "4.1.18",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-darwin-x64/-/oxide-darwin-x64-4.1.18.tgz",
+      "integrity": "sha512-FL5oxr2xQsFrc3X9o1fjHKBYBMD1QZNyc1Xzw/h5Qu4XnEBi3dZn96HcHm41c/euGV+GRiXFfh2hUCyKi/e+yw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-linux-x64-gnu": {
+      "version": "4.1.18",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-x64-gnu/-/oxide-linux-x64-gnu-4.1.18.tgz",
+      "integrity": "sha512-v3gyT0ivkfBLoZGF9LyHmts0Isc8jHZyVcbzio6Wpzifg/+5ZJpDiRiUhDLkcr7f/r38SWNe7ucxmGW3j3Kb/g==",
+      "cpu": [
+        "x64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-win32-x64-msvc": {
+      "version": "4.1.18",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-win32-x64-msvc/-/oxide-win32-x64-msvc-4.1.18.tgz",
+      "integrity": "sha512-bJWbyYpUlqamC8dpR7pfjA0I7vdF6t5VpUGMWRkXVE3AXgIZjYUYAK7II1GNaxR8J1SSrSrppRar8G++JekE3Q==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
       ],
       "engines": {
         "node": ">= 10"
@@ -10135,11 +10186,74 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
         "darwin"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-darwin-x64": {
+      "version": "1.30.2",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.30.2.tgz",
+      "integrity": "sha512-oBZgKchomuDYxr7ilwLcyms6BCyLn0z8J0+ZZmfpjwg9fRVZIR5/GMXd7r9RH94iDhld3UmSjBM6nXWM2TfZTQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-x64-gnu": {
+      "version": "1.30.2",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.30.2.tgz",
+      "integrity": "sha512-Cfd46gdmj1vQ+lR6VRTTadNHu6ALuw2pKR9lYq4FnhvgBc4zWY1EtZcAc6EffShbb1MFrIPfLDXD6Xprbnni4w==",
+      "cpu": [
+        "x64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-win32-x64-msvc": {
+      "version": "1.30.2",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.30.2.tgz",
+      "integrity": "sha512-5g1yc73p+iAkid5phb4oVFMB45417DkRevRbt/El/gKXJk4jid+vPFF/AXbxn05Aky8PapwzZrdJShv5C0avjw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
       ],
       "engines": {
         "node": ">= 12.0.0"
@@ -14082,7 +14196,7 @@
     },
     "src/frontend": {
       "name": "kiji-privacy-proxy",
-      "version": "1.3.1",
+      "version": "1.4.0",
       "dependencies": {
         "@sentry/electron": "^7.13.0",
         "@types/dompurify": "^3.2.0",
@@ -14124,6 +14238,14 @@
         "webpack": "^5.105.4",
         "webpack-cli": "^7.0.3",
         "webpack-dev-server": "^5.2.5"
+      },
+      "optionalDependencies": {
+        "@tailwindcss/oxide-darwin-arm64": "4.1.18",
+        "@tailwindcss/oxide-darwin-x64": "4.1.18",
+        "@tailwindcss/oxide-linux-x64-gnu": "4.1.18",
+        "lightningcss-darwin-arm64": "1.30.2",
+        "lightningcss-darwin-x64": "1.30.2",
+        "lightningcss-linux-x64-gnu": "1.30.2"
       }
     },
     "src/frontend/node_modules/accepts": {

--- a/src/frontend/package.json
+++ b/src/frontend/package.json
@@ -63,6 +63,14 @@
     "webpack-cli": "^7.0.3",
     "webpack-dev-server": "^5.2.5"
   },
+  "optionalDependencies": {
+    "@tailwindcss/oxide-darwin-arm64": "4.1.18",
+    "@tailwindcss/oxide-darwin-x64": "4.1.18",
+    "@tailwindcss/oxide-linux-x64-gnu": "4.1.18",
+    "lightningcss-darwin-arm64": "1.30.2",
+    "lightningcss-darwin-x64": "1.30.2",
+    "lightningcss-linux-x64-gnu": "1.30.2"
+  },
   "build": {
     "appId": "com.kiji.proxy",
     "productName": "Kiji Privacy Proxy",


### PR DESCRIPTION
## What this fixes

The build fails during the frontend web bundle step (`npm run build`) with:

```
[webpack-cli] Error: Cannot find module '../lightningcss.linux-x64-gnu.node'
```

(and the equivalent `tailwindcss-oxide.linux-x64-gnu.node` for `@tailwindcss/oxide`).

## Root cause

The committed `package-lock.json` only carried native package **nodes for `darwin-arm64`** — it was generated on Apple Silicon. On any other platform the platform-specific native binaries for `lightningcss` and `@tailwindcss/oxide` have no resolution entry in the lockfile, so npm silently skips them (they're optional). This breaks the Tailwind/webpack build under both `npm ci` and `npm install` (npm/cli#4828).

## Fix

Declare the required platform binaries as **direct `optionalDependencies`** in `src/frontend/package.json`, so npm records their nodes in the lockfile and installs them reliably on each matching platform. Their `os`/`cpu` constraints mean each installs only where it applies, so this is safe across platforms.

Covers the platforms this repo actually builds on:
- **linux-x64-gnu** — `build_linux.sh` / `build_deb.sh`, `_build-linux.yml`
- **macOS arm64 + x64** — `build_dmg.sh`, `_build-dmg.yml`

## Verification

- Clean `npm ci` now installs the Linux native binaries and both modules load.
- `bash src/scripts/build_linux.sh` completes end to end and produces the release tarball.