### PR TITLE
chore: add changeset for streaming coding agents support

### DIFF
--- a/.changeset/streaming-coding-agents.md
+++ b/.changeset/streaming-coding-agents.md
@@ -1,0 +1,5 @@
+---
+"kiji-privacy-proxy": minor
+---
+
+Add streaming (SSE) support for coding agents: Claude Code and Codex responses are now streamed through the proxy with PII masking/restoration applied per delta, including tool-call arguments. Streamed requests are also recorded in the dashboard metrics.


### PR DESCRIPTION
Adds a changeset for the streaming support feature (#586) so the changesets release workflow picks it up as a **minor** bump of `kiji-privacy-proxy`.