### PR TITLE
test(processor): add unit tests for response.go's ProcessResponse

### DIFF
--- a/src/backend/processor/response_test.go
+++ b/src/backend/processor/response_test.go
@@ -1,6 +1,11 @@
 package processor
 
-import "testing"
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/dataiku/kiji-proxy/src/backend/providers"
+)
 
 // A generated dummy can coincide with a real original from another mapping
 // ("Priya"→"Nicole" alongside "Claude"→"Priya"). Restoration must be a single
@@ -45,4 +50,231 @@ func TestRestorePII_EmptyAndPlainCases(t *testing.T) {
 	if got != want {
 		t.Errorf("RestorePII = %q, want %q", got, want)
 	}
+}
+
+// --- ProcessResponse ---
+//
+// ProcessResponse's own job (as opposed to RestorePII/BuildRestorer above) is:
+// gate on content type, parse-or-passthrough on bad JSON, delegate the actual
+// per-provider restoration to provider.RestoreMaskedResponse, stamp
+// original_response + proxy_metadata, and (per its own comments) fall back to
+// the original body if the modified JSON can't be re-marshaled.
+//
+// providers.Provider can't be faked from this package: CreateMaskedRequest and
+// RestoreMaskedResponse are typed against unexported function types
+// (maskPIIInTextType, restorePIIType, ...) declared in package providers, so
+// only types defined inside that package can satisfy the interface. This
+// mirrors the existing convention in proxy/handler_test.go: use a real
+// provider (OpenAIProvider costs nothing to construct — it makes no network
+// calls until a request is actually sent) rather than invent a workaround.
+// That also means these tests exercise the exact wiring production traffic
+// uses, not a hand-rolled substitute for it.
+
+// stubLoggingConfig is a minimal LoggingConfig with AddProxyNotice
+// controllable per test; the other flags only affect log output, not behavior
+// under test.
+type stubLoggingConfig struct {
+	addProxyNotice bool
+}
+
+func (s stubLoggingConfig) GetLogResponses() bool   { return false }
+func (s stubLoggingConfig) GetLogVerbose() bool     { return false }
+func (s stubLoggingConfig) GetAddProxyNotice() bool { return s.addProxyNotice }
+
+func newTestOpenAIProvider() providers.Provider {
+	return providers.NewOpenAIProvider("api.openai.com", "sk-test", nil)
+}
+
+func TestProcessResponse_NonJSONContentType_PassesThroughUnchanged(t *testing.T) {
+	rp := NewResponseProcessor(nil, stubLoggingConfig{})
+	provider := newTestOpenAIProvider()
+
+	// If ProcessResponse mistakenly tried to restore this as JSON, it would be
+	// altered (masked value replaced) or rejected; either way it wouldn't come
+	// back byte-for-byte identical.
+	body := []byte("plain text response containing DUMMY_NAME, not JSON at all")
+	got := rp.ProcessResponse(body, "text/plain; charset=utf-8", map[string]string{"DUMMY_NAME": "Alice"}, &provider)
+
+	if string(got) != string(body) {
+		t.Errorf("ProcessResponse changed a non-JSON body: got %q, want unchanged %q", got, body)
+	}
+}
+
+func TestProcessResponse_MalformedJSON_ReturnsOriginalBodyUnchanged(t *testing.T) {
+	rp := NewResponseProcessor(nil, stubLoggingConfig{})
+	provider := newTestOpenAIProvider()
+
+	body := []byte(`{"choices": [ this is not valid json`)
+	got := rp.ProcessResponse(body, "application/json", map[string]string{}, &provider)
+
+	if string(got) != string(body) {
+		t.Errorf("expected malformed JSON to pass through unchanged, got %q, want %q", got, body)
+	}
+}
+
+// TestProcessResponse_RestoresPIIAndStampsMetadata drives ProcessResponse with
+// a real OpenAI Chat Completions response shape and checks all three of its
+// documented effects: the masked placeholder in the actual response content is
+// restored, the untouched original bytes are preserved under
+// original_response, and proxy_metadata is stamped.
+func TestProcessResponse_RestoresPIIAndStampsMetadata(t *testing.T) {
+	rp := NewResponseProcessor(nil, stubLoggingConfig{addProxyNotice: false})
+	provider := newTestOpenAIProvider()
+
+	body := []byte(`{"choices":[{"message":{"content":"Hello DUMMY_NAME, how can I help?"}}]}`)
+	maskedToOriginal := map[string]string{"DUMMY_NAME": "Alice"}
+
+	// "application/json; charset=utf-8" must still match the substring-based
+	// content-type gate in ProcessResponse.
+	got := rp.ProcessResponse(body, "application/json; charset=utf-8", maskedToOriginal, &provider)
+
+	var out map[string]interface{}
+	if err := json.Unmarshal(got, &out); err != nil {
+		t.Fatalf("ProcessResponse produced invalid JSON: %v (body: %s)", err, got)
+	}
+
+	choices, _ := out["choices"].([]interface{})
+	if len(choices) != 1 {
+		t.Fatalf("expected 1 choice to survive, got %#v", out["choices"])
+	}
+	message, _ := choices[0].(map[string]interface{})["message"].(map[string]interface{})
+	content, _ := message["content"].(string)
+	if content != "Hello Alice, how can I help?" {
+		t.Errorf("restored content = %q, want PII restored to the original", content)
+	}
+
+	// original_response must carry the untouched input bytes, not the restored
+	// version, so a client with the mapping can always recover exactly what the
+	// upstream provider actually sent. It's embedded via json.RawMessage, so it
+	// decodes as nested JSON (not a string) — re-marshal it to compare.
+	rawOriginal, ok := out["original_response"]
+	if !ok {
+		t.Fatalf("expected original_response field to be present, got %#v", out)
+	}
+	rawOriginalBytes, err := json.Marshal(rawOriginal)
+	if err != nil {
+		t.Fatalf("failed to re-marshal original_response: %v", err)
+	}
+	if !jsonEqual(t, string(rawOriginalBytes), string(body)) {
+		t.Errorf("original_response = %s, want it to equal the untouched input %s", rawOriginalBytes, body)
+	}
+
+	meta, ok := out["proxy_metadata"].(map[string]interface{})
+	if !ok {
+		t.Fatalf("expected proxy_metadata field, got %#v", out["proxy_metadata"])
+	}
+	if intercepted, _ := meta["intercepted"].(bool); !intercepted {
+		t.Errorf("expected proxy_metadata.intercepted = true, got %v", meta["intercepted"])
+	}
+	if svc, _ := meta["service"].(string); svc == "" {
+		t.Error("expected proxy_metadata.service to be set")
+	}
+}
+
+// TestProcessResponse_MappingMissLeavesTextUntouched covers the issue's
+// "mapping miss" case: a masked token in the response body has no entry in
+// maskedToOriginal (e.g. the mapping expired, or the token was echoed back
+// from context rather than actually produced by masking). RestorePII/
+// BuildRestorer only replace keys present in the map, so an unmapped token is
+// left exactly as the model wrote it — it is not blanked out, corrupted, or
+// mistaken for a different key.
+func TestProcessResponse_MappingMissLeavesTextUntouched(t *testing.T) {
+	rp := NewResponseProcessor(nil, stubLoggingConfig{})
+	provider := newTestOpenAIProvider()
+
+	body := []byte(`{"choices":[{"message":{"content":"Your code is UNMAPPED_TOKEN_123"}}]}`)
+	// Mapping only covers a different token; UNMAPPED_TOKEN_123 has no entry.
+	maskedToOriginal := map[string]string{"DUMMY_OTHER": "SomeoneElse"}
+
+	got := rp.ProcessResponse(body, "application/json", maskedToOriginal, &provider)
+
+	var out map[string]interface{}
+	if err := json.Unmarshal(got, &out); err != nil {
+		t.Fatalf("invalid JSON: %v", err)
+	}
+	choices, _ := out["choices"].([]interface{})
+	message, _ := choices[0].(map[string]interface{})["message"].(map[string]interface{})
+	content, _ := message["content"].(string)
+	if content != "Your code is UNMAPPED_TOKEN_123" {
+		t.Errorf("expected unmapped token to pass through unchanged, got %q", content)
+	}
+}
+
+// TestProcessResponse_ProviderErrorStillStampsMetadata covers the "restore
+// failed but we keep going" path: when the response doesn't match any shape
+// the provider recognizes (OpenAIProvider.RestoreMaskedResponse returns an
+// error when there's no "choices" field), ProcessResponse only logs the
+// error — it never aborts and returns the raw body instead. proxy_metadata
+// must still be added so callers can't distinguish "nothing to restore" from
+// "the proxy silently gave up".
+func TestProcessResponse_ProviderErrorStillStampsMetadata(t *testing.T) {
+	rp := NewResponseProcessor(nil, stubLoggingConfig{})
+	provider := newTestOpenAIProvider()
+
+	body := []byte(`{"unexpected_shape": true}`)
+	got := rp.ProcessResponse(body, "application/json", nil, &provider)
+
+	var out map[string]interface{}
+	if err := json.Unmarshal(got, &out); err != nil {
+		t.Fatalf("ProcessResponse produced invalid JSON despite a provider error: %v", err)
+	}
+	if _, ok := out["proxy_metadata"]; !ok {
+		t.Error("expected proxy_metadata to still be stamped even when the provider's restore returns an error")
+	}
+	if _, ok := out["unexpected_shape"]; !ok {
+		t.Error("expected the original (unrecognized) field to survive untouched")
+	}
+}
+
+// TestProcessResponse_AddProxyNoticeIsWiredToProvider confirms the
+// interceptionNotice string ProcessResponse builds, and the getAddProxyNotice
+// callback it passes through, actually reach the provider and take effect —
+// this is the one piece of ProcessResponse's contract that isn't visible from
+// its own code, only from how OpenAIProvider is allowed to use what it's
+// handed (see OpenAIProvider.RestoreMaskedResponse).
+func TestProcessResponse_AddProxyNoticeIsWiredToProvider(t *testing.T) {
+	rp := NewResponseProcessor(nil, stubLoggingConfig{addProxyNotice: true})
+	provider := newTestOpenAIProvider()
+
+	body := []byte(`{"choices":[{"message":{"content":"plain content"}}]}`)
+	got := rp.ProcessResponse(body, "application/json", map[string]string{}, &provider)
+
+	var out map[string]interface{}
+	if err := json.Unmarshal(got, &out); err != nil {
+		t.Fatalf("invalid JSON: %v", err)
+	}
+	choices, _ := out["choices"].([]interface{})
+	message, _ := choices[0].(map[string]interface{})["message"].(map[string]interface{})
+	content, _ := message["content"].(string)
+	if want := "plain content\n\n[This response was intercepted and processed by Kiji Privacy Proxy service]"; content != want {
+		t.Errorf("content = %q, want %q", content, want)
+	}
+}
+
+// Note on the json.Marshal failure branch in ProcessResponse ("Failed to
+// marshal modified JSON" -> return the original body): reaching it would
+// require a provider's RestoreMaskedResponse to write a value into the
+// decoded map that encoding/json cannot marshal (e.g. a channel or func).
+// json.Unmarshal itself can never produce such a value, and every real
+// provider (OpenAI/Anthropic/Gemini/Mistral/Custom) only ever writes strings
+// back into the map. providers.Provider's parameter types are unexported
+// (see above), so this package can't substitute a misbehaving fake to force
+// that branch either. It is exercised here only implicitly, by the fact that
+// every other test's realistic response bodies all marshal successfully.
+
+// jsonEqual compares two JSON strings for structural equality (whitespace/key
+// order shouldn't matter — original_response is re-encoded raw bytes, not a
+// byte-for-byte guarantee).
+func jsonEqual(t *testing.T, a, b string) bool {
+	t.Helper()
+	var av, bv interface{}
+	if err := json.Unmarshal([]byte(a), &av); err != nil {
+		t.Fatalf("invalid JSON %q: %v", a, err)
+	}
+	if err := json.Unmarshal([]byte(b), &bv); err != nil {
+		t.Fatalf("invalid JSON %q: %v", b, err)
+	}
+	aBytes, _ := json.Marshal(av)
+	bBytes, _ := json.Marshal(bv)
+	return string(aBytes) == string(bBytes)
 }


### PR DESCRIPTION
Closes #429.

`response.go` already had decent coverage on `RestorePII`/`BuildRestorer`, but `ProcessResponse` — the function that actually gets called on every response — had none. This adds it.

`ProcessResponse`'s job, stripped down: gate on content type, try to parse the body as JSON (fall back to the original bytes if it doesn't parse), hand off to the provider's `RestoreMaskedResponse` for the actual PII restoration, then stamp `original_response` and `proxy_metadata` onto the result.

What's covered:

- Non-JSON content type passes through byte-for-byte, untouched.
- Malformed JSON falls back to the original body instead of erroring or emitting something truncated.
- The main path, end-to-end: a masked placeholder in `choices[0].message.content` gets restored to the real value, `original_response` holds the untouched input bytes, and `proxy_metadata` gets stamped. `original_response` is embedded via `json.RawMessage`, so it comes back as nested JSON rather than a string when you unmarshal the result — took me a second to realize the test needed to account for that instead of comparing it as a plain string.
- The "mapping miss" case from the issue: if a masked-looking token in the response has no matching entry in `maskedToOriginal`, it's left exactly as-is — not corrupted, not blanked.
- What happens when the provider can't make sense of the response shape (`RestoreMaskedResponse` errors on something without a `choices` field): `ProcessResponse` just logs it and keeps going, and `proxy_metadata` still gets added. That distinction matters — a caller shouldn't be able to tell "nothing needed restoring" apart from "the proxy gave up silently."
- The proxy-notice wiring: confirms the interception-notice string `ProcessResponse` builds, and the `getAddProxyNotice` callback it passes down, actually reach `OpenAIProvider` and show up in the response content.

**Why a real `OpenAIProvider` instead of a mock:** `providers.Provider`'s `CreateMaskedRequest` and `RestoreMaskedResponse` are typed against unexported function types declared inside package `providers` (`maskPIIInTextType`, `restorePIIType`, etc.), so nothing defined outside that package can satisfy the interface — a hand-rolled fake from `processor_test` simply won't compile. I noticed `proxy/handler_test.go` already deals with this the same way (constructs a real `OpenAIProvider`, which is cheap since it makes no network calls until you actually send a request), so I followed that existing pattern instead of inventing a different one.

One thing I left deliberately undone: the `json.Marshal` failure fallback (the branch where re-marshaling the modified response fails and `ProcessResponse` returns the original body) isn't separately tested. Triggering it needs a provider to write something unmarshalable — a channel, a func — into the decoded response map, and every real provider only ever writes strings. Given the same unexported-interface constraint above, there's no way to force that branch through the public API without a fake, which isn't buildable here. I left a comment explaining that rather than skip it silently.

This repo requires first-time contributors to add themselves to `CONTRIBUTORS.md`; that entry is in #609 (one of three PRs from the same pass), not duplicated here.

```mermaid
flowchart LR
    A[Incoming response body\n+ contentType + maskedToOriginal] --> B{JSON content type?}
    B -->|no| C[return body unchanged]:::covered
    B -->|yes| D{json.Unmarshal succeeds?}
    D -->|no, malformed| E[return original body]:::covered
    D -->|yes| F["provider.RestoreMaskedResponse\n(e.g. OpenAIProvider)"]
    F -->|error - unrecognized shape| G[log only, keep going]:::covered
    F -->|ok| H["response with PII\nrestored in place\n(unmapped tokens left as-is)"]:::covered
    G --> I[stamp original_response\n+ proxy_metadata]:::covered
    H --> I
    I --> J{json.Marshal succeeds?}
    J -->|yes| K[return modified JSON]:::covered
    J -->|no - not reachable\nvia public API today| L[return original body]:::uncovered

    classDef covered fill:#1f4d2c,stroke:#27ae60,color:#fff
    classDef uncovered stroke-dasharray: 5 5
```

Test plan:
- `go test ./src/backend/processor/...` passes
- `go vet` and `gofmt -l` clean
- For the two most consequential assertions — the `original_response` field and the provider-error-keeps-going behavior — I temporarily removed the field and made the error path return early instead of continuing, confirmed both new tests failed as expected, then reverted
